### PR TITLE
feat: agent group governance

### DIFF
--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -104,6 +104,9 @@ logger = logging.getLogger("clawchat_gateway.adapter")
 inbound_trace = logging.getLogger("clawchat_gateway.inbound_trace")
 
 CLAWCHAT_PLUGIN_PLATFORM = "hermes"
+# Number of prior group messages to prepend as context when the agent is @-mentioned.
+# Internal constant; not user-facing.
+MENTION_CONTEXT_N = 10
 TYPING_REFRESH_SECONDS = 10.0
 INBOUND_RATE_WINDOW_SECONDS = 30.0
 INBOUND_RATE_WARN_THRESHOLD = 5
@@ -1457,6 +1460,68 @@ class ClawChatAdapter(BasePlatformAdapter):
             return
         await self._handle_inbound(inbound)
 
+    def _batch_message_ids(self, inbound: InboundMessage) -> set[str]:
+        """Return the set of all constituent message_ids in the current dispatched batch.
+
+        For a coalesced group batch the raw_message contains ``"messages": [frame, ...]``
+        where each frame carries the original ``payload.message_id``.  For a single
+        (non-coalesced) message the raw_message IS the frame.  We collect ALL ids so
+        the prior-context dedup covers every message already present in the turn body.
+        """
+        ids: set[str] = set()
+        raw = inbound.raw_message if isinstance(inbound.raw_message, dict) else {}
+        if raw.get("clawchat_group_batch") is True:
+            frames = raw.get("messages")
+            if isinstance(frames, list):
+                for frame in frames:
+                    if isinstance(frame, dict):
+                        payload = frame.get("payload")
+                        if isinstance(payload, dict):
+                            mid = payload.get("message_id")
+                            if isinstance(mid, str) and mid:
+                                ids.add(mid)
+        else:
+            payload = raw.get("payload")
+            if isinstance(payload, dict):
+                mid = payload.get("message_id")
+                if isinstance(mid, str) and mid:
+                    ids.add(mid)
+        return ids
+
+    def _build_mention_prior_context_text(self, inbound: InboundMessage) -> str | None:
+        """Fetch and format prior context rows for a @-mention turn in a group.
+
+        Returns a formatted string of prior messages (oldest-first), excluding any
+        messages already present in the current dispatched batch, or None when there
+        is nothing to prepend (store unavailable, no rows after dedup, etc.).
+        """
+        if self._store is None:
+            return None
+        account_id = self._account_id()
+        if not account_id or not inbound.chat_id:
+            return None
+        try:
+            rows = self._store.list_recent_group_messages(account_id, inbound.chat_id, MENTION_CONTEXT_N)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "clawchat prior context fetch failed chat_id=%s",
+                inbound.chat_id,
+                exc_info=True,
+            )
+            return None
+        if not rows:
+            return None
+        # Dedupe: exclude any row whose message_id is already in the current batch.
+        batch_ids = self._batch_message_ids(inbound)
+        prior = [row for row in rows if row.get("message_id") not in batch_ids]
+        if not prior:
+            return None
+        lines = ["[ClawChat group prior context — oldest first]"]
+        for row in prior:
+            text = str(row.get("text") or "")
+            lines.append(text)
+        return "\n".join(lines)
+
     async def _handle_inbound(self, inbound: InboundMessage) -> None:
         if inbound.chat_type == "group":
             await self._ensure_group_participants_metadata(inbound.chat_id)
@@ -1473,8 +1538,19 @@ class ClawChatAdapter(BasePlatformAdapter):
         downloaded_media = await self._download_inbound_media(inbound)
         media_urls = [str(item.local_path) for item in downloaded_media]
         media_types = [item.mime for item in downloaded_media]
+        # Prepend prior group context when the agent is @-mentioned.
+        event_text = inbound.text
+        if inbound.chat_type == "group" and inbound.was_mentioned:
+            prior_context = self._build_mention_prior_context_text(inbound)
+            if prior_context:
+                event_text = prior_context + "\n\n" + event_text
+                logger.info(
+                    "clawchat mention prior context injected chat_id=%s rows=%d",
+                    inbound.chat_id,
+                    prior_context.count("\n"),
+                )
         event = MessageEvent(
-            text=inbound.text,
+            text=event_text,
             message_type=MessageType.TEXT,
             source=source,
             raw_message={

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -90,6 +90,7 @@ from clawchat_gateway.protocol import (
     new_frame_id,
     new_message_id,
 )
+from clawchat_gateway.group_settings import GroupSettingsCache
 from clawchat_gateway.storage import get_clawchat_store
 from clawchat_gateway.terminal_send import (
     clear_clawchat_mention_sender,
@@ -389,6 +390,7 @@ class ClawChatAdapter(BasePlatformAdapter):
             on_state_change=self._on_state_change,
             on_signal=self._on_signal,
             on_auth_logout=self._on_auth_logout,
+            on_notify_signal=self._on_notify_signal,
         )
         self._active_runs_by_id: dict[str, _ActiveRun] = {}
         self._active_chat_runs: dict[str, str] = {}
@@ -419,6 +421,7 @@ class ClawChatAdapter(BasePlatformAdapter):
             max_wait_seconds=30.0,
             dispatch=self._handle_inbound,
         )
+        self._group_settings_cache = GroupSettingsCache()
         try:
             self._store = get_clawchat_store()
         except Exception:  # noqa: BLE001
@@ -543,12 +546,27 @@ class ClawChatAdapter(BasePlatformAdapter):
             self._schedule_activation_bootstrap()
             self._schedule_owner_metadata_refresh()
             await self._schedule_reconnect_conversation_refresh()
+            # Re-pull group settings on every (re)connect — best-effort.
+            self._spawn_group_settings_refresh("reconnect")
         logger.info("clawchat state -> %s", state.value)
 
     async def _on_signal(self, frame: dict[str, Any]) -> None:
         if frame.get("event") != "chat.metadata.invalidated":
             return
         await self._handle_metadata_invalidated(frame)
+
+    async def _on_notify_signal(self, frame: dict[str, Any]) -> None:
+        """Handle inbound ``notify.signal`` frames dispatched by the connection.
+
+        Currently reacts to ``agent.config.changed`` by re-pulling the per-group
+        settings cache.  All other signal types are ignored here (the connection
+        already deduped and logged them).
+        """
+        payload = frame.get("payload")
+        if not isinstance(payload, dict):
+            return
+        if payload.get("type") == "agent.config.changed":
+            self._spawn_group_settings_refresh("signal")
 
     async def _on_auth_logout(self, message: str) -> None:
         """User-visible notification on permanent token expiry (token-refresh §C.1).
@@ -581,6 +599,42 @@ class ClawChatAdapter(BasePlatformAdapter):
             )
         except Exception:  # noqa: BLE001
             logger.warning("clawchat auth-logout notification send failed", exc_info=True)
+
+    def _spawn_group_settings_refresh(self, reason: str) -> None:
+        """Fire-and-forget task to re-pull per-group settings from the backend.
+
+        Best-effort: any exception is caught and logged; the connection is never
+        affected.  ``reason`` is used only for structured logging.
+        """
+        task = asyncio.ensure_future(self._refresh_group_settings(reason=reason))
+        task.add_done_callback(lambda t: None)
+
+    async def _refresh_group_settings(self, *, reason: str) -> None:
+        """Pull ``GET /v1/agents/me/group-settings`` and merge into the cache."""
+        cfg = self._clawchat_config
+        if not cfg.token or not cfg.base_url:
+            logger.debug("clawchat group-settings refresh skipped reason=%s (no token/base_url)", reason)
+            return
+        try:
+            client = ClawChatApiClient(
+                base_url=cfg.base_url or DEFAULT_BASE_URL,
+                token=cfg.token,
+                user_id=cfg.user_id,
+                device_id=self._connection.session_device_id(),
+            )
+            rows = await client.get_my_group_settings()
+            self._group_settings_cache.apply_fetched(rows)
+            logger.info(
+                "clawchat group-settings refreshed reason=%s rows=%d",
+                reason,
+                len(rows),
+            )
+        except Exception:  # noqa: BLE001 — best-effort; must never crash the connection
+            logger.warning(
+                "clawchat group-settings refresh failed reason=%s",
+                reason,
+                exc_info=True,
+            )
 
     async def _schedule_reconnect_conversation_refresh(self) -> None:
         if self._store is None:

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -45,6 +45,7 @@ from clawchat_gateway.clawchat_metadata import (
 from clawchat_gateway.config import (
     ClawChatConfig,
     effective_group_command_mode,
+    effective_group_mode,
     effective_group_sessions_per_user,
 )
 from clawchat_gateway.connection import (
@@ -90,7 +91,7 @@ from clawchat_gateway.protocol import (
     new_frame_id,
     new_message_id,
 )
-from clawchat_gateway.group_settings import GroupSettingsCache
+from clawchat_gateway.group_settings import EffectiveSettings, GroupSettingsCache
 from clawchat_gateway.storage import get_clawchat_store
 from clawchat_gateway.terminal_send import (
     clear_clawchat_mention_sender,
@@ -1380,6 +1381,30 @@ class ClawChatAdapter(BasePlatformAdapter):
             self._remember_reply_preview(
                 message_id=protocol_message_id, inbound=inbound
             )
+        if inbound.chat_type == "group":
+            _static_reply_mode = effective_group_mode(self._clawchat_config, inbound.chat_id)
+            _static_fallback = EffectiveSettings(
+                muted=False,
+                reply_mode=_static_reply_mode,
+                batch_delay_seconds=10,
+            )
+            _eff = self._group_settings_cache.effective(inbound.chat_id, _static_fallback)
+            if _eff.muted:
+                logger.info(
+                    "clawchat group muted chat_id=%s sender_id=%s reason=backend_mute",
+                    inbound.chat_id,
+                    inbound.sender_id,
+                )
+                return
+            if _eff.reply_mode == "mention" and not inbound.was_mentioned:
+                logger.info(
+                    "clawchat group non-mention dropped chat_id=%s sender_id=%s reason=reply_mode_mention",
+                    inbound.chat_id,
+                    inbound.sender_id,
+                )
+                return
+        else:
+            _eff = None
         if await self._handle_owner_forwarded_approval(inbound):
             return
         if inbound.chat_type == "group":
@@ -1410,7 +1435,10 @@ class ClawChatAdapter(BasePlatformAdapter):
                 )
                 await self._handle_inbound(inbound)
                 return
-            self._group_message_coalescer.enqueue(inbound)
+            self._group_message_coalescer.enqueue(
+                inbound,
+                idle_seconds_override=float(_eff.batch_delay_seconds) if _eff is not None else None,
+            )
             if inbound.was_mentioned:
                 logger.info(
                     "clawchat flushing group batch immediately chat_id=%s sender_id=%s text_len=%d reason=agent_mention",

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -653,12 +653,27 @@ class ClawChatAdapter(BasePlatformAdapter):
 
         Best-effort: any exception is caught and logged; the connection is never
         affected.  ``reason`` is used only for structured logging.
+
+        The monotonic fetch sequence is allocated SYNCHRONOUSLY here — before the
+        task is scheduled — so sequence order matches spawn/dispatch order.
+        Assigning it inside the task body would let a later-spawned refresh whose
+        task happens to run first claim the LOWER sequence; an older snapshot
+        running later with a HIGHER sequence could then overwrite newer settings,
+        defeating the stale-snapshot ordering guard.
         """
-        task = asyncio.ensure_future(self._refresh_group_settings(reason=reason))
+        self._group_settings_fetch_seq += 1
+        sequence = self._group_settings_fetch_seq
+        task = asyncio.ensure_future(
+            self._refresh_group_settings(reason=reason, sequence=sequence)
+        )
         task.add_done_callback(lambda t: None)
 
-    async def _refresh_group_settings(self, *, reason: str) -> None:
-        """Pull ``GET /v1/agents/me/group-settings`` and merge into the cache."""
+    async def _refresh_group_settings(self, *, reason: str, sequence: int) -> None:
+        """Pull ``GET /v1/agents/me/group-settings`` and merge into the cache.
+
+        ``sequence`` is the pre-allocated dispatch order assigned by
+        :meth:`_spawn_group_settings_refresh`; it must not be re-derived here.
+        """
         cfg = self._clawchat_config
         if not cfg.token or not cfg.base_url:
             logger.debug("clawchat group-settings refresh skipped reason=%s (no token/base_url)", reason)
@@ -667,18 +682,12 @@ class ClawChatAdapter(BasePlatformAdapter):
             self._group_settings_ready.set()
             return
         try:
-            client = ClawChatApiClient(
-                base_url=cfg.base_url or DEFAULT_BASE_URL,
-                token=cfg.token,
-                user_id=cfg.user_id,
-                device_id=self._connection.session_device_id(),
+            # Route through the reactive refresh-and-retry wrapper so a 401/403
+            # (the api client now propagates auth errors) rotates the token and
+            # retries once, instead of being swallowed as non-authoritative.
+            result = await self._rest_with_auth_retry(
+                lambda client: client.get_my_group_settings()
             )
-            # Assign the fetch sequence at dispatch so concurrent pulls (e.g. a
-            # reconnect refresh overlapping an agent.config.changed signal) are
-            # ordered: a later-arriving but lower-sequence snapshot is dropped.
-            self._group_settings_fetch_seq += 1
-            sequence = self._group_settings_fetch_seq
-            result = await client.get_my_group_settings()
             if result.authoritative:
                 # Authoritative HTTP 200 (possibly empty => "zero overrides").
                 self._group_settings_cache.apply_fetched(result.rows, sequence)
@@ -882,10 +891,18 @@ class ClawChatAdapter(BasePlatformAdapter):
 
     def _new_api_client(self) -> ClawChatApiClient:
         """Build an authenticated REST client from the live in-memory token."""
+        device_id = None
+        connection = getattr(self, "_connection", None)
+        if connection is not None:
+            try:
+                device_id = connection.session_device_id()
+            except Exception:  # noqa: BLE001
+                device_id = None
         return ClawChatApiClient(
             base_url=self._clawchat_config.base_url,
             token=self._clawchat_config.token,
             user_id=self._clawchat_config.user_id,
+            device_id=device_id,
         )
 
     async def _rest_with_auth_retry(

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -1499,7 +1499,10 @@ class ClawChatAdapter(BasePlatformAdapter):
         """
         if self._store is None:
             return None
-        account_id = self._account_id()
+        # The persist path (_record_message / _claim_message_once) writes rows under
+        # account_id="default"; read with the same value so paired adapters (whose
+        # _account_id() is the ClawChat user_id) still match the stored rows.
+        account_id = "default"
         if not account_id or not inbound.chat_id:
             return None
         try:

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -8,6 +8,8 @@ import logging
 import os
 import re
 import time
+
+from clawchat_gateway.no_reply import is_no_reply_token
 from collections import OrderedDict, deque
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field, replace
@@ -3243,8 +3245,7 @@ class ClawChatAdapter(BasePlatformAdapter):
             return self._clawchat_config.runtime_status_messages
 
     def _is_noop_response_text(self, content: str) -> bool:
-        text = content.strip()
-        return text in {NO_REPLY_TOKEN, LEGACY_EMPTY_RESPONSE_TOKEN}
+        return is_no_reply_token(content) or content.strip() == LEGACY_EMPTY_RESPONSE_TOKEN
 
     def _is_no_reply_token_prefix(self, content: str) -> bool:
         text = content.strip()

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -432,6 +432,10 @@ class ClawChatAdapter(BasePlatformAdapter):
             dispatch=self._handle_inbound,
         )
         self._group_settings_cache = GroupSettingsCache()
+        # Monotonic fetch sequence assigned per dispatched settings pull. Passed
+        # into apply_fetched so a stale/out-of-order snapshot (empty or not) can
+        # never roll the cache back; see GroupSettingsCache.apply_fetched.
+        self._group_settings_fetch_seq = 0
         # Set once the first per-(re)connect settings refresh finishes (success OR
         # fallback). Group dispatch waits on this so a muted / mention-only group is
         # never answered via static fallback before the GET lands. Cleared at the
@@ -669,13 +673,29 @@ class ClawChatAdapter(BasePlatformAdapter):
                 user_id=cfg.user_id,
                 device_id=self._connection.session_device_id(),
             )
-            rows = await client.get_my_group_settings()
-            self._group_settings_cache.apply_fetched(rows)
-            logger.info(
-                "clawchat group-settings refreshed reason=%s rows=%d",
-                reason,
-                len(rows),
-            )
+            # Assign the fetch sequence at dispatch so concurrent pulls (e.g. a
+            # reconnect refresh overlapping an agent.config.changed signal) are
+            # ordered: a later-arriving but lower-sequence snapshot is dropped.
+            self._group_settings_fetch_seq += 1
+            sequence = self._group_settings_fetch_seq
+            result = await client.get_my_group_settings()
+            if result.authoritative:
+                # Authoritative HTTP 200 (possibly empty => "zero overrides").
+                self._group_settings_cache.apply_fetched(result.rows, sequence)
+                logger.info(
+                    "clawchat group-settings refreshed reason=%s rows=%d seq=%d",
+                    reason,
+                    len(result.rows),
+                    sequence,
+                )
+            else:
+                # Non-authoritative (404 / endpoint-absent / non-2xx / network):
+                # preserve the cache — this carries no override information.
+                logger.info(
+                    "clawchat group-settings refresh non-authoritative reason=%s seq=%d (cache preserved)",
+                    reason,
+                    sequence,
+                )
         except Exception:  # noqa: BLE001 — best-effort; must never crash the connection
             logger.warning(
                 "clawchat group-settings refresh failed reason=%s",

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 
-from clawchat_gateway.no_reply import is_no_reply_token
+from clawchat_gateway.no_reply import is_no_reply_token, is_no_reply_token_prefix
 from collections import OrderedDict, deque
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field, replace
@@ -112,6 +112,10 @@ MENTION_CONTEXT_N = 10
 TYPING_REFRESH_SECONDS = 10.0
 INBOUND_RATE_WINDOW_SECONDS = 30.0
 INBOUND_RATE_WARN_THRESHOLD = 5
+# Max time a group message waits for the first per-group settings refresh to land
+# (or fall back) after (re)connect, before it is dispatched with whatever the cache
+# holds. Bounds the gate so a dead network never stalls group traffic indefinitely.
+GROUP_SETTINGS_READY_TIMEOUT_SECONDS = 5.0
 COMPLETED_RUN_CACHE_MAX = 1024
 REPLY_PREVIEW_CACHE_MAX = 512
 # Hermes core can deliver the SAME finished response to the platform twice in one
@@ -428,6 +432,11 @@ class ClawChatAdapter(BasePlatformAdapter):
             dispatch=self._handle_inbound,
         )
         self._group_settings_cache = GroupSettingsCache()
+        # Set once the first per-(re)connect settings refresh finishes (success OR
+        # fallback). Group dispatch waits on this so a muted / mention-only group is
+        # never answered via static fallback before the GET lands. Cleared at the
+        # start of each reconnect-triggered refresh; never gates non-group traffic.
+        self._group_settings_ready = asyncio.Event()
         try:
             self._store = get_clawchat_store()
         except Exception:  # noqa: BLE001
@@ -552,7 +561,10 @@ class ClawChatAdapter(BasePlatformAdapter):
             self._schedule_activation_bootstrap()
             self._schedule_owner_metadata_refresh()
             await self._schedule_reconnect_conversation_refresh()
-            # Re-pull group settings on every (re)connect — best-effort.
+            # Re-pull group settings on every (re)connect — best-effort. Gate group
+            # dispatch on this first refresh so replayed/live group messages are not
+            # answered from a stale/empty cache before the fresh settings land.
+            self._group_settings_ready.clear()
             self._spawn_group_settings_refresh("reconnect")
         logger.info("clawchat state -> %s", state.value)
 
@@ -606,6 +618,25 @@ class ClawChatAdapter(BasePlatformAdapter):
         except Exception:  # noqa: BLE001
             logger.warning("clawchat auth-logout notification send failed", exc_info=True)
 
+    async def _await_group_settings_ready(self) -> None:
+        """Block until the first per-(re)connect settings refresh has landed/fallen back.
+
+        Bounded by ``GROUP_SETTINGS_READY_TIMEOUT_SECONDS`` so a dead network never
+        stalls group traffic — on timeout we proceed with whatever the cache holds.
+        Tolerant of adapters constructed without ``__init__`` (test harnesses that
+        pre-populate the cache): a missing event means "already ready".
+        """
+        event = getattr(self, "_group_settings_ready", None)
+        if event is None or event.is_set():
+            return
+        try:
+            await asyncio.wait_for(event.wait(), timeout=GROUP_SETTINGS_READY_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "clawchat group-settings gate timed out after %.1fs; proceeding with cached settings",
+                GROUP_SETTINGS_READY_TIMEOUT_SECONDS,
+            )
+
     def _spawn_group_settings_refresh(self, reason: str) -> None:
         """Fire-and-forget task to re-pull per-group settings from the backend.
 
@@ -620,6 +651,9 @@ class ClawChatAdapter(BasePlatformAdapter):
         cfg = self._clawchat_config
         if not cfg.token or not cfg.base_url:
             logger.debug("clawchat group-settings refresh skipped reason=%s (no token/base_url)", reason)
+            # No credentials to fetch with: release the gate so group dispatch
+            # falls back to static settings instead of blocking until timeout.
+            self._group_settings_ready.set()
             return
         try:
             client = ClawChatApiClient(
@@ -641,6 +675,10 @@ class ClawChatAdapter(BasePlatformAdapter):
                 reason,
                 exc_info=True,
             )
+        finally:
+            # Always release the gate (success OR failure/fallback) so group
+            # dispatch never stalls on a refresh that failed.
+            self._group_settings_ready.set()
 
     async def _schedule_reconnect_conversation_refresh(self) -> None:
         if self._store is None:
@@ -1387,6 +1425,11 @@ class ClawChatAdapter(BasePlatformAdapter):
                 message_id=protocol_message_id, inbound=inbound
             )
         if inbound.chat_type == "group":
+            # Gate ONLY group dispatch on the first per-(re)connect settings refresh
+            # so a muted / mention-only group is not answered from a stale/empty
+            # cache via static fallback before the GET lands. Bounded so a dead
+            # network never stalls group traffic; non-group traffic is never gated.
+            await self._await_group_settings_ready()
             _static_reply_mode = effective_group_mode(self._clawchat_config, inbound.chat_id)
             _static_fallback = EffectiveSettings(
                 muted=False,
@@ -1505,8 +1548,15 @@ class ClawChatAdapter(BasePlatformAdapter):
         account_id = "default"
         if not account_id or not inbound.chat_id:
             return None
+        # The current batch's own rows are persisted into clawchat_messages BEFORE
+        # this fetch runs, so a bare LIMIT MENTION_CONTEXT_N would be consumed by
+        # the batch itself (a full N-message batch starves prior context to zero).
+        # Over-fetch by the batch size so MENTION_CONTEXT_N genuine prior rows
+        # remain after the batch's ids are deduped out, then trim.
+        batch_ids = self._batch_message_ids(inbound)
+        fetch_limit = MENTION_CONTEXT_N + len(batch_ids)
         try:
-            rows = self._store.list_recent_group_messages(account_id, inbound.chat_id, MENTION_CONTEXT_N)
+            rows = self._store.list_recent_group_messages(account_id, inbound.chat_id, fetch_limit)
         except Exception:  # noqa: BLE001
             logger.warning(
                 "clawchat prior context fetch failed chat_id=%s",
@@ -1516,9 +1566,11 @@ class ClawChatAdapter(BasePlatformAdapter):
             return None
         if not rows:
             return None
-        # Dedupe: exclude any row whose message_id is already in the current batch.
-        batch_ids = self._batch_message_ids(inbound)
+        # Dedupe: exclude any row whose message_id is already in the current batch,
+        # then keep only the most-recent MENTION_CONTEXT_N (oldest-first input).
         prior = [row for row in rows if row.get("message_id") not in batch_ids]
+        if len(prior) > MENTION_CONTEXT_N:
+            prior = prior[-MENTION_CONTEXT_N:]
         if not prior:
             return None
         lines = ["[ClawChat group prior context — oldest first]"]
@@ -3251,8 +3303,11 @@ class ClawChatAdapter(BasePlatformAdapter):
         return is_no_reply_token(content) or content.strip() == LEGACY_EMPTY_RESPONSE_TOKEN
 
     def _is_no_reply_token_prefix(self, content: str) -> bool:
-        text = content.strip()
-        return bool(text) and text != NO_REPLY_TOKEN and NO_REPLY_TOKEN.startswith(text)
+        # Recognize prefixes of *every* accepted no-reply / silent variant
+        # (bracket / case / spacing), not just the canonical NO_REPLY_TOKEN, so a
+        # streamed first chunk like ``[clawchat`` or ``<CLAWCHAT:NO`` is held back
+        # instead of leaking into chat.
+        return is_no_reply_token_prefix(content)
 
     def _is_pure_silent_response(self, fragments: list[dict[str, Any]]) -> bool:
         return (

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -1582,6 +1582,14 @@ class ClawChatAdapter(BasePlatformAdapter):
     async def _handle_inbound(self, inbound: InboundMessage) -> None:
         if inbound.chat_type == "group":
             await self._ensure_group_participants_metadata(inbound.chat_id)
+        # Capture command-ness from the ORIGINAL inbound text before any batch
+        # re-rendering rewrites ``.text`` (a coalesced batch would no longer start
+        # with the slash). The group command-dispatch path sends the raw inbound
+        # here with the slash leading; this flag gates the prior-context prepend.
+        is_group_command = (
+            inbound.chat_type == "group"
+            and _is_known_hermes_slash_command(inbound.text)
+        )
         inbound = self._refresh_group_batch_sender_context(inbound)
         reply_to_message_id, reply_to_text = self._extract_reply_fields(
             inbound.reply_preview
@@ -1596,8 +1604,19 @@ class ClawChatAdapter(BasePlatformAdapter):
         media_urls = [str(item.local_path) for item in downloaded_media]
         media_types = [item.mime for item in downloaded_media]
         # Prepend prior group context when the agent is @-mentioned.
+        #
+        # A group slash command is dispatched through this same path and MUST
+        # carry a structured mention to clear the reply-mode gate, so it arrives
+        # here with was_mentioned=True. Prepending prior-context text in front of
+        # it would push the leading slash off the start of the turn, so Hermes
+        # would no longer recognize it as a command and would treat it as chat.
+        # Skip the injection for command turns so the slash stays at the start.
         event_text = inbound.text
-        if inbound.chat_type == "group" and inbound.was_mentioned:
+        if (
+            inbound.chat_type == "group"
+            and inbound.was_mentioned
+            and not is_group_command
+        ):
             prior_context = self._build_mention_prior_context_text(inbound)
             if prior_context:
                 event_text = prior_context + "\n\n" + event_text

--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -558,14 +558,21 @@ class ClawChatAdapter(BasePlatformAdapter):
         if state == ConnectionState.READY:
             self._clawchat_config = self._connection.config
             self._auth_failed = False
-            self._schedule_activation_bootstrap()
-            self._schedule_owner_metadata_refresh()
-            await self._schedule_reconnect_conversation_refresh()
             # Re-pull group settings on every (re)connect — best-effort. Gate group
             # dispatch on this first refresh so replayed/live group messages are not
             # answered from a stale/empty cache before the fresh settings land.
+            #
+            # Clear the gate BEFORE the first await below: the read loop can
+            # dispatch replayed/live group frames concurrently while this handler
+            # is parked on an await, so the gate must already be cleared by then or
+            # those in-flight frames would skip _await_group_settings_ready() and
+            # use the stale cache. The refresh task re-sets it on completion /
+            # fallback. Non-group traffic is never gated.
             self._group_settings_ready.clear()
+            self._schedule_activation_bootstrap()
+            self._schedule_owner_metadata_refresh()
             self._spawn_group_settings_refresh("reconnect")
+            await self._schedule_reconnect_conversation_refresh()
         logger.info("clawchat state -> %s", state.value)
 
     async def _on_signal(self, frame: dict[str, Any]) -> None:

--- a/clawchat_gateway/api_client.py
+++ b/clawchat_gateway/api_client.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from clawchat_gateway.device_id import get_device_id
-from clawchat_gateway.group_settings import GroupSettings
+from clawchat_gateway.group_settings import GroupSettings, GroupSettingsFetchResult
 
 logger = logging.getLogger(__name__)
 
@@ -123,20 +123,26 @@ class ClawChatApiClient:
         self._device_id = device_id or get_device_id()
         self._timeout = timeout if timeout and timeout > 0 else DEFAULT_REQUEST_TIMEOUT
 
-    async def get_my_group_settings(self) -> list[GroupSettings]:
+    async def get_my_group_settings(self) -> GroupSettingsFetchResult:
         """Fetch per-group agent settings for this agent.
 
-        Returns the list of ``GroupSettings`` rows from
-        ``GET /v1/agents/me/group-settings``.  On HTTP 404 (older backend that
-        does not yet expose this endpoint) returns an empty list instead of
-        raising, so callers can treat it as "no overrides".
+        Returns a :class:`GroupSettingsFetchResult` whose ``authoritative`` flag
+        distinguishes an HTTP 200 (the complete override snapshot, possibly
+        empty — ``authoritative=True``) from every NON-authoritative outcome
+        (HTTP 404 / endpoint-absent / non-2xx / network error —
+        ``authoritative=False``, empty rows). Only authoritative results may
+        replace the cache; an HTTP 200 with an EMPTY list authoritatively means
+        "zero overrides" and clears it, whereas a 404 (older backend without the
+        endpoint) carries no information and must be a no-op.
         """
         try:
             data = await self._call_json("GET", "/v1/agents/me/group-settings")
-        except ClawChatApiError as exc:
-            if exc.status == 404:
-                return []
-            raise
+        except ClawChatApiError:
+            # Any error (404 / non-2xx / network / non-JSON) is NON-authoritative:
+            # it says nothing about the agent's actual override set, so preserve
+            # the cache. Logged here for visibility; callers treat it as a no-op.
+            logger.debug("clawchat group-settings fetch non-authoritative", exc_info=True)
+            return GroupSettingsFetchResult(authoritative=False)
         rows: list[GroupSettings] = []
         for item in data.get("settings") or []:
             if not isinstance(item, dict):
@@ -153,7 +159,7 @@ class ClawChatApiClient:
                 )
             except (KeyError, TypeError, ValueError):
                 logger.warning("clawchat group-settings: skipping malformed row %r", item)
-        return rows
+        return GroupSettingsFetchResult(authoritative=True, rows=rows)
 
     async def get_my_profile(self) -> dict:
         return await self._call_json("GET", "/v1/users/me")

--- a/clawchat_gateway/api_client.py
+++ b/clawchat_gateway/api_client.py
@@ -134,13 +134,24 @@ class ClawChatApiClient:
         replace the cache; an HTTP 200 with an EMPTY list authoritatively means
         "zero overrides" and clears it, whereas a 404 (older backend without the
         endpoint) carries no information and must be a no-op.
+
+        Auth (401/403) errors are NOT swallowed: they propagate (``kind ==
+        "auth"``) so the caller's reactive token-refresh-and-retry path runs.
         """
         try:
             data = await self._call_json("GET", "/v1/agents/me/group-settings")
-        except ClawChatApiError:
-            # Any error (404 / non-2xx / network / non-JSON) is NON-authoritative:
-            # it says nothing about the agent's actual override set, so preserve
-            # the cache. Logged here for visibility; callers treat it as a no-op.
+        except ClawChatApiError as exc:
+            # Auth (401/403) errors MUST propagate so the caller's reactive
+            # token-refresh-and-retry path runs (mirrors the OpenClaw plugin:
+            # auth throws drive refresh). Swallowing them would leave a
+            # mute/reply-mode change unloadable until some unrelated REST call
+            # happened to refresh an expired access token.
+            if exc.kind == "auth":
+                raise
+            # Every OTHER error (404 / non-2xx / network / non-JSON) is
+            # NON-authoritative: it says nothing about the agent's actual
+            # override set, so preserve the cache. Logged here for visibility;
+            # callers treat it as a no-op.
             logger.debug("clawchat group-settings fetch non-authoritative", exc_info=True)
             return GroupSettingsFetchResult(authoritative=False)
         rows: list[GroupSettings] = []

--- a/clawchat_gateway/api_client.py
+++ b/clawchat_gateway/api_client.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from clawchat_gateway.device_id import get_device_id
+from clawchat_gateway.group_settings import GroupSettings
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +122,38 @@ class ClawChatApiClient:
         self._user_id = user_id
         self._device_id = device_id or get_device_id()
         self._timeout = timeout if timeout and timeout > 0 else DEFAULT_REQUEST_TIMEOUT
+
+    async def get_my_group_settings(self) -> list[GroupSettings]:
+        """Fetch per-group agent settings for this agent.
+
+        Returns the list of ``GroupSettings`` rows from
+        ``GET /v1/agents/me/group-settings``.  On HTTP 404 (older backend that
+        does not yet expose this endpoint) returns an empty list instead of
+        raising, so callers can treat it as "no overrides".
+        """
+        try:
+            data = await self._call_json("GET", "/v1/agents/me/group-settings")
+        except ClawChatApiError as exc:
+            if exc.status == 404:
+                return []
+            raise
+        rows: list[GroupSettings] = []
+        for item in data.get("settings") or []:
+            if not isinstance(item, dict):
+                continue
+            try:
+                rows.append(
+                    GroupSettings(
+                        conversation_id=str(item["conversation_id"]),
+                        muted=bool(item.get("muted", False)),
+                        reply_mode=str(item.get("reply_mode", "all")),
+                        batch_delay_seconds=int(item.get("batch_delay_seconds", 0)),
+                        version=int(item.get("version", 0)),
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                logger.warning("clawchat group-settings: skipping malformed row %r", item)
+        return rows
 
     async def get_my_profile(self) -> dict:
         return await self._call_json("GET", "/v1/users/me")

--- a/clawchat_gateway/connection.py
+++ b/clawchat_gateway/connection.py
@@ -147,6 +147,10 @@ OnSignal = Callable[[dict[str, Any]], Awaitable[None]]
 # the user-visible status/chat message (§C.1). Receives the human-readable
 # message text.
 OnAuthLogout = Callable[[str], Awaitable[None]]
+# Called for every freshly-observed ``notify.signal`` frame (after dedup).
+# Receives the full raw frame dict.  Use to react to specific ``payload.type``
+# values (e.g. ``"agent.config.changed"``).
+OnNotifySignal = Callable[[dict[str, Any]], Awaitable[None]]
 
 
 class ClawChatConnection:
@@ -167,6 +171,7 @@ class ClawChatConnection:
         on_state_change: OnStateChange | None = None,
         on_signal: OnSignal | None = None,
         on_auth_logout: OnAuthLogout | None = None,
+        on_notify_signal: OnNotifySignal | None = None,
         account_id: str = "default",
     ) -> None:
         self._cfg = config
@@ -174,6 +179,7 @@ class ClawChatConnection:
         self._on_state_change = on_state_change
         self._on_signal = on_signal
         self._on_auth_logout = on_auth_logout
+        self._on_notify_signal = on_notify_signal
         self._account_id = account_id
         self._state = ConnectionState.DISCONNECTED
         self._ws: Any = None
@@ -1089,10 +1095,8 @@ class ClawChatConnection:
                 await on_signal(frame)
             return
         if self._state == ConnectionState.READY and ftype in (None, "event") and frame.get("event") == "notify.signal":
-            # §9.4 reliable system notification. The plugin holds no friend/roster
-            # cache (REST-on-demand), so observe + dedup only — no side effect. The
-            # live frame and its reliable-inbox replay share an event_id and
-            # collapse to one observation. Wire a reaction here if ever needed.
+            # §9.4 reliable system notification. Dedup by event_id so the live
+            # frame and its reliable-inbox replay collapse to one observation.
             payload = frame.get("payload") if isinstance(frame.get("payload"), dict) else {}
             outcome = self._notify_signal_observer.observe(frame)
             logger.info(
@@ -1113,6 +1117,13 @@ class ClawChatConnection:
                     ],
                 )
             )
+            # Forward freshly-observed signals to the adapter callback so it can
+            # react to specific signal types (e.g. agent.config.changed).
+            if outcome == "observed" and self._on_notify_signal is not None:
+                try:
+                    await self._on_notify_signal(frame)
+                except Exception:  # noqa: BLE001
+                    logger.exception("on_notify_signal raised")
             return
         if self._state == ConnectionState.READY and ftype in (None, "event") and frame.get("event") == "replay.done":
             # §11.5 terminal control frame: device replay drained, live begins.

--- a/clawchat_gateway/group_message_coalescer.py
+++ b/clawchat_gateway/group_message_coalescer.py
@@ -104,10 +104,10 @@ class GroupMessageCoalescer:
             await asyncio.gather(*tasks, return_exceptions=True)
         await self.flush(chat_id)
 
-    async def _flush_after_idle(self, chat_id: str, *, idle_seconds: float | None = None) -> None:
+    async def _flush_after_idle(self, chat_id: str, *, idle_seconds: float) -> None:
         task = asyncio.current_task()
         try:
-            await self._sleep(idle_seconds if idle_seconds is not None else self._idle_seconds)
+            await self._sleep(idle_seconds)
             await self.flush(chat_id)
         except asyncio.CancelledError:
             raise

--- a/clawchat_gateway/group_message_coalescer.py
+++ b/clawchat_gateway/group_message_coalescer.py
@@ -57,22 +57,22 @@ class GroupMessageCoalescer:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._max_wait_tasks: dict[str, asyncio.Task[None]] = {}
 
-    def enqueue(self, message: InboundMessage) -> None:
+    def enqueue(self, message: InboundMessage, *, idle_seconds_override: float | None = None) -> None:
         batch = self._pending.setdefault(message.chat_id, [])
         batch.append(message)
-        self._reset_idle_task(message.chat_id)
+        self._reset_idle_task(message.chat_id, idle_seconds_override=idle_seconds_override)
         if message.chat_id not in self._max_wait_tasks:
             self._max_wait_tasks[message.chat_id] = asyncio.create_task(
                 self._flush_after_max_wait(message.chat_id),
                 name=f"clawchat-group-coalesce-max-{message.chat_id}",
             )
 
-    def _reset_idle_task(self, chat_id: str) -> None:
+    def _reset_idle_task(self, chat_id: str, *, idle_seconds_override: float | None = None) -> None:
         task = self._tasks.pop(chat_id, None)
         if task is not None:
             task.cancel()
         self._tasks[chat_id] = asyncio.create_task(
-            self._flush_after_idle(chat_id),
+            self._flush_after_idle(chat_id, idle_seconds=idle_seconds_override if idle_seconds_override is not None else self._idle_seconds),
             name=f"clawchat-group-coalesce-idle-{chat_id}",
         )
 
@@ -104,10 +104,10 @@ class GroupMessageCoalescer:
             await asyncio.gather(*tasks, return_exceptions=True)
         await self.flush(chat_id)
 
-    async def _flush_after_idle(self, chat_id: str) -> None:
+    async def _flush_after_idle(self, chat_id: str, *, idle_seconds: float | None = None) -> None:
         task = asyncio.current_task()
         try:
-            await self._sleep(self._idle_seconds)
+            await self._sleep(idle_seconds if idle_seconds is not None else self._idle_seconds)
             await self.flush(chat_id)
         except asyncio.CancelledError:
             raise

--- a/clawchat_gateway/group_settings.py
+++ b/clawchat_gateway/group_settings.py
@@ -13,9 +13,14 @@ Usage
 Cache contract
 --------------
 - Keyed by ``conversation_id``.
-- Version-monotonic: ``apply_fetched`` silently ignores any row whose ``version``
-  is strictly less than the currently cached version for that conversation.
-  Rows with ``version >= cached`` replace the stored entry.
+- Replacement set: ``get_my_group_settings()`` returns the *complete* snapshot of
+  the agent's rows, so ``apply_fetched`` rebuilds the cache from a non-empty fetch
+  and drops conversations absent from it (a reset / left group must not linger).
+- Empty fetch is a no-op, not a wipe (older backends with no endpoint also return
+  an empty list via HTTP 404 — clearing on that would discard valid overrides).
+- Version-monotonic: ``apply_fetched`` keeps the cached row when a fetched row's
+  ``version`` is strictly less than the cached one (guards a refresh racing behind
+  a newer ``agent.config.changed`` signal).
 - Unknown chats (no backend row) fall through to ``static_fallback``.
 """
 
@@ -61,16 +66,31 @@ class GroupSettingsCache:
         self._rows: dict[str, GroupSettings] = {}
 
     def apply_fetched(self, rows: list[GroupSettings]) -> None:
-        """Merge a fresh list of backend rows into the cache.
+        """Replace the cache with a fresh *complete* fetch of backend rows.
 
-        For each row, if the cache already holds a newer-or-equal version for
-        the same ``conversation_id`` the incoming row is silently discarded.
-        Rows with ``version >= cached_version`` replace the stored entry.
+        ``GET /v1/agents/me/group-settings`` returns the full snapshot of all
+        stored rows for this agent, so a conversation omitted from the fetch no
+        longer has an override and must be dropped — otherwise a stale muted /
+        reply_mode would linger until restart.
+
+        An **empty** fetch is treated as a no-op rather than a wipe: an empty
+        list is also what older backends (no endpoint -> HTTP 404) return, and
+        clearing on that signal would discard valid overrides. Per-conversation
+        version-monotonicity is preserved: a fetched row whose ``version`` is
+        strictly older than the cached one is kept (guards a refresh racing
+        behind a newer ``agent.config.changed`` signal).
         """
+        if not rows:
+            return
+        rebuilt: dict[str, GroupSettings] = {}
         for row in rows:
             existing = self._rows.get(row.conversation_id)
-            if existing is None or row.version >= existing.version:
-                self._rows[row.conversation_id] = row
+            # Keep the newer cached row if this fetch raced behind a signal.
+            if existing is not None and row.version < existing.version:
+                rebuilt[row.conversation_id] = existing
+            else:
+                rebuilt[row.conversation_id] = row
+        self._rows = rebuilt
 
     def effective(self, chat_id: str, static_fallback: EffectiveSettings) -> EffectiveSettings:
         """Return the effective settings for *chat_id*.

--- a/clawchat_gateway/group_settings.py
+++ b/clawchat_gateway/group_settings.py
@@ -1,0 +1,88 @@
+"""Per-group agent settings: dataclasses, in-memory cache, and effective-settings lookup.
+
+Mirrors the OpenClaw plugin's ``GroupSettingsCache`` (Task 6) in Python.
+
+Usage
+-----
+1. At startup (and on every WS reconnect / ``agent.config.changed`` signal), call
+   ``ApiClient.get_my_group_settings()`` and pass the result to
+   ``GroupSettingsCache.apply_fetched()``.
+2. When deciding how to handle an inbound group message, call
+   ``cache.effective(chat_id, static_fallback)`` to get the merged settings.
+
+Cache contract
+--------------
+- Keyed by ``conversation_id``.
+- Version-monotonic: ``apply_fetched`` silently ignores any row whose ``version``
+  is strictly less than the currently cached version for that conversation.
+  Rows with ``version >= cached`` replace the stored entry.
+- Unknown chats (no backend row) fall through to ``static_fallback``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(eq=True, frozen=True)
+class GroupSettings:
+    """A single per-group backend row.
+
+    The ``agent_id`` field returned by the backend is intentionally omitted here —
+    the cache is keyed by ``conversation_id`` and the agent only ever sees its own
+    settings.
+    """
+
+    conversation_id: str
+    muted: bool
+    reply_mode: str  # "all" | "mention"
+    batch_delay_seconds: int
+    version: int
+
+
+@dataclass(eq=True, frozen=True)
+class EffectiveSettings:
+    """The resolved (possibly backend-overridden) settings for a given chat."""
+
+    muted: bool
+    reply_mode: str  # "all" | "mention"
+    batch_delay_seconds: int
+
+
+class GroupSettingsCache:
+    """In-memory, version-monotonic cache of per-group agent settings.
+
+    Thread-safety: the adapter runs in a single asyncio event loop, so no
+    locking is needed.
+    """
+
+    def __init__(self) -> None:
+        # conversation_id -> GroupSettings
+        self._rows: dict[str, GroupSettings] = {}
+
+    def apply_fetched(self, rows: list[GroupSettings]) -> None:
+        """Merge a fresh list of backend rows into the cache.
+
+        For each row, if the cache already holds a newer-or-equal version for
+        the same ``conversation_id`` the incoming row is silently discarded.
+        Rows with ``version >= cached_version`` replace the stored entry.
+        """
+        for row in rows:
+            existing = self._rows.get(row.conversation_id)
+            if existing is None or row.version >= existing.version:
+                self._rows[row.conversation_id] = row
+
+    def effective(self, chat_id: str, static_fallback: EffectiveSettings) -> EffectiveSettings:
+        """Return the effective settings for *chat_id*.
+
+        If the backend has a row for this chat the backend values win; otherwise
+        ``static_fallback`` is returned unchanged.
+        """
+        row = self._rows.get(chat_id)
+        if row is None:
+            return static_fallback
+        return EffectiveSettings(
+            muted=row.muted,
+            reply_mode=row.reply_mode,
+            batch_delay_seconds=row.batch_delay_seconds,
+        )

--- a/clawchat_gateway/group_settings.py
+++ b/clawchat_gateway/group_settings.py
@@ -1,32 +1,40 @@
 """Per-group agent settings: dataclasses, in-memory cache, and effective-settings lookup.
 
-Mirrors the OpenClaw plugin's ``GroupSettingsCache`` (Task 6) in Python.
+Mirrors the OpenClaw plugin's ``GroupSettingsCache`` in Python.
 
 Usage
 -----
 1. At startup (and on every WS reconnect / ``agent.config.changed`` signal), call
-   ``ApiClient.get_my_group_settings()`` and pass the result to
-   ``GroupSettingsCache.apply_fetched()``.
+   ``ApiClient.get_my_group_settings()`` and, ONLY when the result is
+   authoritative, pass ``result.rows`` plus a monotonic per-fetch ``sequence``
+   (incremented at the call site) to ``GroupSettingsCache.apply_fetched()``. A
+   non-authoritative result must be a no-op (preserve cache).
 2. When deciding how to handle an inbound group message, call
    ``cache.effective(chat_id, static_fallback)`` to get the merged settings.
 
 Cache contract
 --------------
 - Keyed by ``conversation_id``.
-- Replacement set: ``get_my_group_settings()`` returns the *complete* snapshot of
-  the agent's rows, so ``apply_fetched`` rebuilds the cache from a non-empty fetch
-  and drops conversations absent from it (a reset / left group must not linger).
-- Empty fetch is a no-op, not a wipe (older backends with no endpoint also return
-  an empty list via HTTP 404 — clearing on that would discard valid overrides).
-- Version-monotonic: ``apply_fetched`` keeps the cached row when a fetched row's
-  ``version`` is strictly less than the cached one (guards a refresh racing behind
-  a newer ``agent.config.changed`` signal).
+- Replacement set: an authoritative ``get_my_group_settings()`` returns the
+  *complete* snapshot of the agent's rows, so ``apply_fetched`` REPLACES the
+  cache and drops conversations absent from it (a reset / left group must not
+  linger). An authoritative EMPTY snapshot means "zero overrides" and clears the
+  cache.
+- Authoritative-only: only HTTP 200 results reach ``apply_fetched``. A
+  non-authoritative outcome (404 / endpoint-absent / non-2xx / network error)
+  carries no information about the override set and must be a no-op at the call
+  site — it must NOT be passed here.
+- Sequence-monotonic: each dispatched fetch is tagged with a monotonic
+  ``sequence`` at the call site. ``apply_fetched`` drops any pull whose
+  ``sequence`` is ``<=`` the last applied one (a stale/out-of-order snapshot,
+  empty or not, must never roll the cache back). ``version`` is only an
+  in-snapshot tiebreaker when a conversation repeats within one pull.
 - Unknown chats (no backend row) fall through to ``static_fallback``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(eq=True, frozen=True)
@@ -46,6 +54,24 @@ class GroupSettings:
 
 
 @dataclass(eq=True, frozen=True)
+class GroupSettingsFetchResult:
+    """Outcome of a ``get_my_group_settings()`` call.
+
+    ``authoritative`` is ``True`` only for an HTTP 200 whose envelope parsed; its
+    ``rows`` (possibly empty) are the COMPLETE override snapshot and may replace
+    the cache (an empty ``rows`` then means "zero overrides", which clears it).
+
+    ``authoritative`` is ``False`` for every NON-authoritative outcome — HTTP 404
+    / endpoint-absent / non-2xx / network error. Such a result carries no
+    information about the override set and must be a no-op: ``rows`` is always
+    empty and must never be applied as if the agent had "no overrides".
+    """
+
+    authoritative: bool
+    rows: list[GroupSettings] = field(default_factory=list)
+
+
+@dataclass(eq=True, frozen=True)
 class EffectiveSettings:
     """The resolved (possibly backend-overridden) settings for a given chat."""
 
@@ -55,7 +81,7 @@ class EffectiveSettings:
 
 
 class GroupSettingsCache:
-    """In-memory, version-monotonic cache of per-group agent settings.
+    """In-memory, sequence-monotonic cache of per-group agent settings.
 
     Thread-safety: the adapter runs in a single asyncio event loop, so no
     locking is needed.
@@ -64,33 +90,50 @@ class GroupSettingsCache:
     def __init__(self) -> None:
         # conversation_id -> GroupSettings
         self._rows: dict[str, GroupSettings] = {}
+        # Highest fetch SEQUENCE applied so far. A pull whose sequence is <= this
+        # is a late/out-of-order delivery and is ignored wholesale, so a slow
+        # earlier snapshot can never wipe or roll back newer state. Unlike a
+        # row-version guard, a sequence orders EMPTY pulls too (an empty pull has
+        # no row version to compare), so a stale empty "clear all" can no longer
+        # overtake a newer non-empty snapshot.
+        self._max_applied_sequence: int = -1
 
-    def apply_fetched(self, rows: list[GroupSettings]) -> None:
-        """Replace the cache with a fresh *complete* fetch of backend rows.
+    def apply_fetched(self, rows: list[GroupSettings], sequence: int) -> None:
+        """Replace the cache from a COMPLETE, AUTHORITATIVE backend snapshot.
 
-        ``GET /v1/agents/me/group-settings`` returns the full snapshot of all
-        stored rows for this agent, so a conversation omitted from the fetch no
-        longer has an override and must be dropped — otherwise a stale muted /
-        reply_mode would linger until restart.
+        ``GET /v1/agents/me/group-settings`` is a full pull: an authoritative
+        HTTP 200 returns every stored per-group override for this agent, and a
+        row that was reset/deleted on the backend simply disappears from the
+        response (absent => default). So an authoritative pull REPLACES the
+        cache, pruning conversations that vanished — merging would leave reset
+        rows cached forever. An authoritative 200 with an EMPTY list means "the
+        agent has zero overrides" and clears the cache.
 
-        An **empty** fetch is treated as a no-op rather than a wipe: an empty
-        list is also what older backends (no endpoint -> HTTP 404) return, and
-        clearing on that signal would discard valid overrides. Per-conversation
-        version-monotonicity is preserved: a fetched row whose ``version`` is
-        strictly older than the cached one is kept (guards a refresh racing
-        behind a newer ``agent.config.changed`` signal).
+        Callers MUST only invoke this for authoritative HTTP 200 results. A
+        non-authoritative outcome (404 / endpoint-absent / non-2xx / network
+        error) must be a no-op at the call site and must NOT be passed here,
+        because it carries no information about the agent's actual override set.
+
+        Out-of-order protection: each dispatched fetch is tagged with a monotonic
+        ``sequence`` at the call site. A pull whose ``sequence`` is ``<=`` the
+        last applied one is dropped entirely (a stale snapshot, empty or not,
+        must never roll the cache back). Row ``version`` is kept only as a
+        within-snapshot tiebreaker when the same conversation repeats.
         """
-        if not rows:
+        # Drop a stale/out-of-order pull. This gates EMPTY pulls too: a late
+        # empty "clear all" with a lower sequence can no longer wipe a newer
+        # snapshot.
+        if sequence <= self._max_applied_sequence:
             return
         rebuilt: dict[str, GroupSettings] = {}
         for row in rows:
-            existing = self._rows.get(row.conversation_id)
-            # Keep the newer cached row if this fetch raced behind a signal.
-            if existing is not None and row.version < existing.version:
-                rebuilt[row.conversation_id] = existing
-            else:
+            existing = rebuilt.get(row.conversation_id)
+            # Within a single snapshot the same conversation should not repeat,
+            # but keep the highest-version row defensively if it does.
+            if existing is None or row.version >= existing.version:
                 rebuilt[row.conversation_id] = row
         self._rows = rebuilt
+        self._max_applied_sequence = sequence
 
     def effective(self, chat_id: str, static_fallback: EffectiveSettings) -> EffectiveSettings:
         """Return the effective settings for *chat_id*.

--- a/clawchat_gateway/inbound.py
+++ b/clawchat_gateway/inbound.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from clawchat_gateway.config import ClawChatConfig, effective_group_mode
+from clawchat_gateway.config import ClawChatConfig
 
 
 @dataclass(frozen=True)
@@ -167,13 +167,6 @@ def parse_inbound_message(
     mentioned_users = _merge_mentioned_users(fragment_mentioned_users, context_mentioned_users)
     mentioned_user_ids = _mentioned_user_ids(mentioned_users)
     was_mentioned = config.user_id in context_mentioned_user_ids
-
-    if (
-        chat_type == "group"
-        and effective_group_mode(config, envelope.get("chat_id") or "") == "mention"
-        and not was_mentioned
-    ):
-        return None
 
     fragments = _coerce_fragments(message)
     text_parts: list[str] = []

--- a/clawchat_gateway/no_reply.py
+++ b/clawchat_gateway/no_reply.py
@@ -2,6 +2,38 @@ import re
 
 _RE = re.compile(r"^[<\[{]?\s*clawchat:(no-reply|silent)\s*/?\s*[>\]}]?$")
 
+# Canonical complete forms (whitespace-collapsed, lowercase) of every accepted
+# no-reply / silent variant.  A streaming first chunk is suppressed when it is a
+# strict prefix of any of these.  Built from the same bracket / token alphabet as
+# ``_RE`` so the streaming guard and the final detection stay in lockstep.
+_OPEN = ["", "<", "[", "{"]
+_CLOSE = ["", "/", ">", "]", "}", "/>", "/]", "/}"]
+_TOKENS = ["clawchat:no-reply", "clawchat:silent"]
+_COMPLETE_FORMS = frozenset(
+    f"{o}{tok}{c}" for o in _OPEN for tok in _TOKENS for c in _CLOSE
+)
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip, and collapse all internal whitespace (mirrors ``_RE``)."""
+    return re.sub(r"\s+", "", text.strip().lower())
+
 
 def is_no_reply_token(text: str) -> bool:
     return bool(_RE.match(text.strip().lower()))
+
+
+def is_no_reply_token_prefix(text: str) -> bool:
+    """True when *text* is a non-empty, strict prefix of some accepted token.
+
+    Used by the streaming output path: the first partial chunk of a no-reply /
+    silent token (in any bracket / case / spacing variant) must be held back so
+    the final-detection suppression guard still fires.  A complete token returns
+    ``False`` here — that case is owned by :func:`is_no_reply_token`.
+    """
+    norm = _normalize(text)
+    if not norm:
+        return False
+    return any(
+        form.startswith(norm) and form != norm for form in _COMPLETE_FORMS
+    )

--- a/clawchat_gateway/no_reply.py
+++ b/clawchat_gateway/no_reply.py
@@ -1,0 +1,7 @@
+import re
+
+_RE = re.compile(r"^[<\[{]?\s*clawchat:(no-reply|silent)\s*/?\s*[>\]}]?$")
+
+
+def is_no_reply_token(text: str) -> bool:
+    return bool(_RE.match(text.strip().lower()))

--- a/clawchat_gateway/storage.py
+++ b/clawchat_gateway/storage.py
@@ -910,6 +910,50 @@ class ClawChatStore:
 
         self._write("finish_connection", write)
 
+    def list_recent_group_messages(
+        self,
+        account_id: str,
+        chat_id: str,
+        limit: int,
+    ) -> list[dict]:
+        """Return the last *limit* messages for (account_id, chat_id), oldest-first.
+
+        Uses the ``idx_clawchat_messages_chat_created`` index.  The query
+        selects DESC to get the most-recent rows, then the caller-visible result
+        is reversed so the list is oldest-first (chronological order for context
+        injection).  Returns an empty list when the store is disabled or on any
+        error.
+        """
+        self.initialize()
+        if self._disabled:
+            return []
+        try:
+            conn = sqlite3.connect(self.db_path)
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT message_id, text, created_at
+                    FROM clawchat_messages
+                    WHERE account_id = ? AND chat_id = ?
+                    ORDER BY created_at DESC, rowid DESC
+                    LIMIT ?
+                    """,
+                    (account_id, chat_id, limit),
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "clawchat database read failed operation=list_recent_group_messages",
+                exc_info=True,
+            )
+            return []
+        # Reverse so result is oldest-first.
+        return [
+            {"message_id": row[0], "text": row[1], "created_at": row[2]}
+            for row in reversed(rows)
+        ]
+
     def record_tool_call(
         self,
         *,

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -140,7 +140,7 @@ def _make_adapter(monkeypatch, *, extra=None, group_settings: list[GroupSettings
     )
     adapter._group_settings_cache = GroupSettingsCache()
     if group_settings:
-        adapter._group_settings_cache.apply_fetched(group_settings)
+        adapter._group_settings_cache.apply_fetched(group_settings, sequence=1)
 
     adapter._dispatched_inbound = dispatched_inbound
     return adapter
@@ -351,7 +351,8 @@ async def test_group_dispatch_waits_for_first_settings_refresh(monkeypatch):
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         adapter._group_settings_cache.apply_fetched(
-            [GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)]
+            [GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)],
+            sequence=1,
         )
         adapter._group_settings_ready.set()
 

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -403,3 +403,83 @@ async def test_non_group_dispatch_not_gated_by_settings(monkeypatch):
     await asyncio.wait_for(adapter._on_message(direct_frame), timeout=1.0)
 
     assert handled, "direct message must be handled without waiting on the group-settings gate"
+
+
+# ---------------------------------------------------------------------------
+# Reconnect race (Issue 2): the settings-ready gate must be CLEARED before the
+# first await in the READY/reconnect path, so an in-flight group frame dispatched
+# while the state-change handler is parked on an await is gated (waits for the
+# refresh) instead of using the stale cache / static fallback.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconnect_clears_gate_before_first_await(monkeypatch):
+    """A group message arriving while _on_state_change(READY) is parked on its
+    first await must be gated until the refresh settles (gate cleared up-front)."""
+    import clawchat_gateway.adapter as adapter_module
+    from clawchat_gateway.connection import ConnectionState
+
+    adapter = _make_adapter(
+        monkeypatch,
+        # Pre-seed a stale muted row to simulate a cache that predates reconnect.
+        group_settings=[
+            GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)
+        ],
+    )
+    # Gate starts SET (as it would after a prior connect settled).
+    adapter._group_settings_ready = asyncio.Event()
+    adapter._group_settings_ready.set()
+
+    # Neutralize the sync bootstrap hooks the READY path calls.
+    adapter._schedule_activation_bootstrap = lambda: None
+    adapter._schedule_owner_metadata_refresh = lambda: None
+    adapter._connection.config = adapter._clawchat_config
+
+    # Block the first await so we can observe the gate state mid-handler.
+    enter_await = asyncio.Event()
+    release_await = asyncio.Event()
+
+    async def _blocking_reconnect_refresh():
+        enter_await.set()
+        await release_await.wait()
+
+    adapter._schedule_reconnect_conversation_refresh = _blocking_reconnect_refresh
+
+    # Capture whether the refresh task was dispatched; do NOT let it set the gate
+    # yet — we control the gate release manually to observe the in-flight window.
+    spawned = []
+    adapter._spawn_group_settings_refresh = lambda reason: spawned.append(reason)
+
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    state_task = asyncio.ensure_future(adapter._on_state_change(ConnectionState.READY))
+    await asyncio.wait_for(enter_await.wait(), timeout=1.0)
+
+    # The handler is now parked on its first await. The gate MUST already be
+    # cleared, and the refresh MUST already have been dispatched.
+    assert not adapter._group_settings_ready.is_set(), "gate must be cleared before the first await"
+    assert spawned == ["reconnect"], "settings refresh must be dispatched before the awaited reconnect refresh"
+
+    # A group message arriving during this window must be GATED, not enqueued via
+    # the stale cache. Dispatch it and give it a moment to park on the gate.
+    msg_task = asyncio.ensure_future(adapter._on_message(_group_frame()))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert enqueued == [], "in-flight group msg must wait on the gate, not use the stale cache"
+    assert not msg_task.done(), "group dispatch must still be blocked on the gate"
+
+    # Settle the refresh: land a fresh (un-muted) snapshot, set the gate, release.
+    adapter._group_settings_cache.apply_fetched(
+        [GroupSettings("cnv_group", muted=False, reply_mode="all", batch_delay_seconds=5, version=2)],
+        sequence=2,
+    )
+    adapter._group_settings_ready.set()
+    release_await.set()
+
+    await asyncio.wait_for(state_task, timeout=1.0)
+    await asyncio.wait_for(msg_task, timeout=1.0)
+
+    # Now released, the message is processed against the FRESH snapshot.
+    assert enqueued, "after the gate releases, the group msg dispatches against the fresh snapshot"

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -484,3 +484,89 @@ async def test_reconnect_clears_gate_before_first_await(monkeypatch):
 
     # Now released, the message is processed against the FRESH snapshot.
     assert enqueued, "after the gate releases, the group msg dispatches against the fresh snapshot"
+
+
+# ---------------------------------------------------------------------------
+# FIX 2: group-settings fetch sequence is allocated SYNCHRONOUSLY at spawn time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_settings_sequence_allocated_at_spawn_not_in_task_body(monkeypatch):
+    """Two refreshes spawned in order must receive sequences in spawn order,
+    regardless of which task body runs first.
+
+    The monotonic sequence must be captured synchronously inside
+    ``_spawn_group_settings_refresh`` (before ``ensure_future``); if it were
+    incremented inside the task body, a later-spawned task that runs first would
+    claim the lower sequence and an older snapshot could overwrite newer state.
+    """
+    adapter = _make_adapter(monkeypatch)
+    adapter._group_settings_fetch_seq = 0
+
+    captured: list[tuple[str, int]] = []
+
+    async def _capture_refresh(*, reason: str, sequence: int) -> None:
+        captured.append((reason, sequence))
+
+    adapter._refresh_group_settings = _capture_refresh
+
+    # Spawn "reconnect" first, then "signal" — sequences must follow spawn order
+    # even though neither task body has run yet at this point.
+    adapter._spawn_group_settings_refresh("reconnect")
+    adapter._spawn_group_settings_refresh("signal")
+
+    # Nothing has run yet, but the sequences are already pinned to spawn order.
+    assert adapter._group_settings_fetch_seq == 2
+
+    # Let the (out-of-order-schedulable) task bodies run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    by_reason = dict(captured)
+    assert by_reason["reconnect"] == 1, "first spawned refresh must get the lower sequence"
+    assert by_reason["signal"] == 2, "later spawned refresh must get the higher sequence"
+
+
+@pytest.mark.asyncio
+async def test_group_settings_auth_error_drives_reactive_refresh(monkeypatch):
+    """A 401/403 from the group-settings pull must drive the reactive token
+    refresh-and-retry (not be swallowed), then apply the retried snapshot."""
+    from clawchat_gateway.api_client import ClawChatApiError
+    from clawchat_gateway.group_settings import GroupSettingsFetchResult
+
+    adapter = _make_adapter(monkeypatch)
+    adapter._group_settings_ready = asyncio.Event()
+    adapter._group_settings_fetch_seq = 0
+
+    refresh_calls = {"n": 0}
+
+    async def _reactive_refresh():
+        refresh_calls["n"] += 1
+        return SimpleNamespace(status="success")
+
+    adapter._connection.reactive_refresh = _reactive_refresh
+    adapter._connection.config = adapter._clawchat_config
+    adapter._connection.session_device_id = lambda: "dev-1"
+
+    attempts = {"n": 0}
+
+    async def _fake_get_my_group_settings(self):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise ClawChatApiError("auth", "token expired", status=401, path="/v1/agents/me/group-settings")
+        return GroupSettingsFetchResult(
+            authoritative=True,
+            rows=[GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=5, version=3)],
+        )
+
+    monkeypatch.setattr(
+        "clawchat_gateway.api_client.ClawChatApiClient.get_my_group_settings",
+        _fake_get_my_group_settings,
+    )
+
+    await adapter._refresh_group_settings(reason="signal", sequence=1)
+
+    assert refresh_calls["n"] == 1, "auth error must drive exactly one reactive refresh"
+    assert attempts["n"] == 2, "the pull must be retried once after a successful refresh"
+    assert adapter._group_settings_ready.is_set(), "gate must be released after the refresh"

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -306,3 +306,17 @@ async def test_enqueue_passes_batch_delay_as_idle_override(monkeypatch):
     await adapter._on_message(_group_frame())
 
     assert calls == [{"idle_seconds_override": 5.0}]
+
+
+@pytest.mark.asyncio
+async def test_static_mention_fallback_drops_non_mention_when_no_backend_row(monkeypatch):
+    """No backend settings row + static group_mode='mention' + non-mention msg -> claimed but NOT enqueued."""
+    adapter = _make_adapter(monkeypatch, extra={"group_mode": "mention"})  # no group_settings
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    await adapter._on_message(_group_frame())  # plain text, no @mention
+
+    assert len(adapter._store.claimed) == 1, "message must be persisted even when static mention gate drops it"
+    assert enqueued == [], "non-mention must NOT be enqueued when static group_mode='mention' and no backend row"
+    assert adapter._dispatched_inbound == []

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -320,3 +320,86 @@ async def test_static_mention_fallback_drops_non_mention_when_no_backend_row(mon
     assert len(adapter._store.claimed) == 1, "message must be persisted even when static mention gate drops it"
     assert enqueued == [], "non-mention must NOT be enqueued when static group_mode='mention' and no backend row"
     assert adapter._dispatched_inbound == []
+
+
+# ---------------------------------------------------------------------------
+# Group-settings readiness gate (finding #1): a group message that arrives while
+# the first per-(re)connect settings refresh is still in flight must WAIT for the
+# refresh to land, so a muted group is honored instead of being answered via the
+# static fallback before the GET completes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_dispatch_waits_for_first_settings_refresh(monkeypatch):
+    """Muted row lands only after the message arrives -> message must NOT enqueue.
+
+    Reproduces the reconnect race: cache starts empty + gate unset; a background
+    task populates the muted row shortly after. Without the gate, _on_message
+    would enqueue via static-all fallback before the refresh; with the gate it
+    waits and honors the mute.
+    """
+    adapter = _make_adapter(monkeypatch)  # cache empty
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    # Simulate "post-reconnect, refresh in flight": gate unset.
+    adapter._group_settings_ready = asyncio.Event()
+
+    async def _land_muted_settings_then_release():
+        # Yield so _on_message is parked on the gate before the cache is filled.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        adapter._group_settings_cache.apply_fetched(
+            [GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)]
+        )
+        adapter._group_settings_ready.set()
+
+    refresh = asyncio.ensure_future(_land_muted_settings_then_release())
+    await adapter._on_message(_group_frame())
+    await refresh
+
+    assert len(adapter._store.claimed) == 1, "message must still be persisted"
+    assert enqueued == [], "muted (landed during gate wait) must be honored, not enqueued via static fallback"
+    assert adapter._dispatched_inbound == []
+
+
+@pytest.mark.asyncio
+async def test_group_dispatch_gate_times_out_and_proceeds(monkeypatch):
+    """If the refresh never releases the gate, group dispatch proceeds after timeout."""
+    import clawchat_gateway.adapter as adapter_module
+
+    adapter = _make_adapter(monkeypatch)
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    adapter._group_settings_ready = asyncio.Event()  # never set
+    monkeypatch.setattr(adapter_module, "GROUP_SETTINGS_READY_TIMEOUT_SECONDS", 0.01)
+
+    await adapter._on_message(_group_frame())
+
+    assert len(adapter._store.claimed) == 1
+    assert len(enqueued) == 1, "after timeout, dispatch proceeds with cached (empty -> static all) settings"
+
+
+@pytest.mark.asyncio
+async def test_non_group_dispatch_not_gated_by_settings(monkeypatch):
+    """A direct (non-group) message must NOT block on the group-settings gate."""
+    adapter = _make_adapter(monkeypatch)
+    adapter._group_settings_ready = asyncio.Event()  # unset; would block group msgs
+
+    direct_frame = dict(_group_frame())
+    direct_frame["chat_type"] = "direct"
+
+    # Stub the direct-path handler so we only assert the gate did not block.
+    handled = []
+
+    async def _fake_handle_inbound(inbound):
+        handled.append(inbound)
+
+    adapter._handle_inbound = _fake_handle_inbound
+
+    # Must return promptly without waiting on the (never-set) gate.
+    await asyncio.wait_for(adapter._on_message(direct_frame), timeout=1.0)
+
+    assert handled, "direct message must be handled without waiting on the group-settings gate"

--- a/tests/test_adapter_dispatch.py
+++ b/tests/test_adapter_dispatch.py
@@ -1,0 +1,308 @@
+"""Tests for adapter dispatch gates: mute, reply-mode, idle override (Task 11 TDD).
+
+Mirrors the OpenClaw Task 7/11 parity tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from collections import OrderedDict
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from clawchat_gateway.config import ClawChatConfig
+from clawchat_gateway.group_message_coalescer import GroupMessageCoalescer
+from clawchat_gateway.group_settings import EffectiveSettings, GroupSettings, GroupSettingsCache
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes (mirror test_reply_mode_surface_removed.py)
+# ---------------------------------------------------------------------------
+
+class _FakeConnection:
+    def __init__(self):
+        self.frames = []
+        self.send_results = []
+
+    async def send_frame(self, frame, **kwargs):
+        self.frames.append((frame, kwargs))
+        if self.send_results:
+            return self.send_results.pop(0)
+        return True
+
+
+class _FakeStore:
+    def __init__(self):
+        self.claimed = []
+
+    def claim_message_once(self, **kwargs):
+        self.claimed.append(kwargs)
+        return True
+
+    def update_message_by_identity(self, **kwargs):
+        pass
+
+    def insert_message(self, **kwargs):
+        pass
+
+    def get_activation_conversation(self, **_kwargs):
+        return None
+
+
+def _load_adapter_class(monkeypatch):
+    gateway = ModuleType("gateway")
+    gateway_config = ModuleType("gateway.config")
+    gateway_platforms = ModuleType("gateway.platforms")
+    gateway_base = ModuleType("gateway.platforms.base")
+
+    class _Platform(str):
+        CLAWCHAT = "clawchat"
+
+    class _BasePlatformAdapter:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class _MessageEvent:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _MessageType:
+        TEXT = "text"
+
+    class _SendResult:
+        def __init__(self, success, error=None, message_id=None):
+            self.success = success
+            self.error = error
+            self.message_id = message_id
+
+    gateway_config.Platform = _Platform
+    gateway_base.BasePlatformAdapter = _BasePlatformAdapter
+    gateway_base.MessageEvent = _MessageEvent
+    gateway_base.MessageType = _MessageType
+    gateway_base.SendResult = _SendResult
+    gateway_platforms.base = gateway_base
+    gateway.config = gateway_config
+    gateway.platforms = gateway_platforms
+
+    monkeypatch.setitem(sys.modules, "gateway", gateway)
+    monkeypatch.setitem(sys.modules, "gateway.config", gateway_config)
+    monkeypatch.setitem(sys.modules, "gateway.platforms", gateway_platforms)
+    monkeypatch.setitem(sys.modules, "gateway.platforms.base", gateway_base)
+
+    import clawchat_gateway.adapter as adapter_module
+    return importlib.reload(adapter_module).ClawChatAdapter
+
+
+def _make_adapter(monkeypatch, *, extra=None, group_settings: list[GroupSettings] | None = None):
+    """Create a minimal adapter bypassing __init__, similar to test_reply_mode_surface_removed."""
+    ClawChatAdapter = _load_adapter_class(monkeypatch)
+    adapter = ClawChatAdapter.__new__(ClawChatAdapter)
+    adapter._clawchat_config = ClawChatConfig.from_platform_config(
+        SimpleNamespace(
+            extra={
+                "websocket_url": "wss://example.test/ws",
+                "token": "token",
+                "user_id": "usr_agent",
+                **(extra or {}),
+            }
+        )
+    )
+    adapter._connection = _FakeConnection()
+    adapter._store = _FakeStore()
+    adapter._memory_root = None
+    adapter._inbound_window = {}
+    adapter._known_chat_types = {}
+    adapter._owner_approval_routes = {}
+    adapter._active_runs_by_id = {}
+    adapter._active_chat_runs = {}
+    adapter._completed_run_ids = set()
+    adapter._completed_run_order = []
+    adapter._recent_emits = OrderedDict()
+    adapter._reply_preview_by_message_id = {}
+    adapter._reply_preview_order = []
+    adapter._conversation_metadata_versions = {}
+    adapter._plugin_report_tasks = set()
+    adapter._profile_sync_tasks = set()
+    adapter._run_counter = 0
+
+    # Task 11: these are normally created in __init__
+    dispatched_inbound = []
+
+    async def _fake_handle_inbound(inbound):
+        dispatched_inbound.append(inbound)
+
+    adapter._group_message_coalescer = GroupMessageCoalescer(
+        idle_seconds=10.0,
+        max_wait_seconds=30.0,
+        dispatch=_fake_handle_inbound,
+    )
+    adapter._group_settings_cache = GroupSettingsCache()
+    if group_settings:
+        adapter._group_settings_cache.apply_fetched(group_settings)
+
+    adapter._dispatched_inbound = dispatched_inbound
+    return adapter
+
+
+def _group_frame(
+    *,
+    chat_id: str = "cnv_group",
+    sender_id: str = "usr_sender",
+    text: str = "hello group",
+    message_id: str = "msg_1",
+    context_mentions: list | None = None,
+) -> dict:
+    return {
+        "version": "2",
+        "event": "message.send",
+        "chat_id": chat_id,
+        "chat_type": "group",
+        "sender": {"id": sender_id, "nick_name": "Sender"},
+        "payload": {
+            "message_id": message_id,
+            "message": {
+                "body": {"fragments": [{"kind": "text", "text": text}]},
+                "context": {"mentions": context_mentions or [], "reply": None},
+            },
+        },
+    }
+
+
+def _mention_frame(
+    *,
+    chat_id: str = "cnv_group",
+    sender_id: str = "usr_sender",
+    text: str = "@Agent hi",
+    message_id: str = "msg_1",
+) -> dict:
+    return {
+        "version": "2",
+        "event": "message.send",
+        "chat_id": chat_id,
+        "chat_type": "group",
+        "sender": {"id": sender_id, "nick_name": "Sender"},
+        "payload": {
+            "message_id": message_id,
+            "message": {
+                "body": {
+                    "fragments": [
+                        {"kind": "mention", "user_id": "usr_agent", "display": "Agent"},
+                        {"kind": "text", "text": " hi"},
+                    ]
+                },
+                "context": {
+                    "mentions": [{"kind": "mention", "user_id": "usr_agent", "display": "Agent"}],
+                    "reply": None,
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mute gate tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_muted_group_persists_but_does_not_enqueue(monkeypatch):
+    """Backend muted=True: message is persisted (claim_message_once called) but NOT enqueued."""
+    adapter = _make_adapter(
+        monkeypatch,
+        group_settings=[GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)],
+    )
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    await adapter._on_message(_group_frame())
+
+    assert len(adapter._store.claimed) == 1, "message must be persisted even when muted"
+    assert enqueued == [], "muted message must NOT be enqueued"
+    assert adapter._dispatched_inbound == []
+
+
+@pytest.mark.asyncio
+async def test_muted_group_stays_silent_even_when_mentioned(monkeypatch):
+    """Muted overrides mention: @-mentioned in a muted group -> no enqueue, no flush."""
+    adapter = _make_adapter(
+        monkeypatch,
+        group_settings=[GroupSettings("cnv_group", muted=True, reply_mode="all", batch_delay_seconds=10, version=1)],
+    )
+    enqueued = []
+    flushed = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    original_flush = adapter._group_message_coalescer.flush_now
+    async def _fake_flush(chat_id):
+        flushed.append(chat_id)
+    adapter._group_message_coalescer.flush_now = _fake_flush
+
+    await adapter._on_message(_mention_frame())
+
+    assert len(adapter._store.claimed) == 1
+    assert enqueued == []
+    assert flushed == []
+
+
+@pytest.mark.asyncio
+async def test_mention_mode_non_mention_persists_but_does_not_enqueue(monkeypatch):
+    """Backend reply_mode='mention', not @-mentioned: persisted, not enqueued."""
+    adapter = _make_adapter(
+        monkeypatch,
+        group_settings=[GroupSettings("cnv_group", muted=False, reply_mode="mention", batch_delay_seconds=10, version=1)],
+    )
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    await adapter._on_message(_group_frame())
+
+    assert len(adapter._store.claimed) == 1
+    assert enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_backend_reply_mode_all_overrides_static_mention(monkeypatch):
+    """Backend reply_mode='all' overrides static group_mode='mention': non-mention dispatched."""
+    adapter = _make_adapter(
+        monkeypatch,
+        extra={"group_mode": "mention"},  # static config says mention-only
+        group_settings=[GroupSettings("cnv_group", muted=False, reply_mode="all", batch_delay_seconds=10, version=1)],
+    )
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    # Non-mention group message
+    await adapter._on_message(_group_frame())
+
+    assert len(adapter._store.claimed) == 1
+    assert len(enqueued) == 1, "backend reply_mode=all must override static mention filter"
+
+
+@pytest.mark.asyncio
+async def test_unknown_group_falls_back_to_static_all_mode_enqueues(monkeypatch):
+    """No backend settings for chat -> static fallback (all) -> enqueued."""
+    adapter = _make_adapter(monkeypatch)  # no group_settings
+    enqueued = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **_kw: enqueued.append(msg)
+
+    await adapter._on_message(_group_frame())
+
+    assert len(adapter._store.claimed) == 1
+    assert len(enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_passes_batch_delay_as_idle_override(monkeypatch):
+    """enqueue is called with idle_seconds_override=batch_delay_seconds from backend."""
+    adapter = _make_adapter(
+        monkeypatch,
+        group_settings=[GroupSettings("cnv_group", muted=False, reply_mode="all", batch_delay_seconds=5, version=1)],
+    )
+    calls = []
+    adapter._group_message_coalescer.enqueue = lambda msg, **kw: calls.append(kw)
+
+    await adapter._on_message(_group_frame())
+
+    assert calls == [{"idle_seconds_override": 5.0}]

--- a/tests/test_context_on_mention.py
+++ b/tests/test_context_on_mention.py
@@ -1,0 +1,467 @@
+"""Task 12 TDD: context-on-mention for group chats (Hermes).
+
+Tests:
+  1. list_recent_group_messages returns last N oldest-first (storage layer).
+  2. A mention turn in a group prepends prior context (adapter layer).
+  3. A multi-message coalesced batch where all batched messages also appear in
+     list_recent_group_messages results → NONE duplicated in prepended context
+     (the bug the OpenClaw task hit).
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sqlite3
+import sys
+from collections import OrderedDict
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from clawchat_gateway.config import ClawChatConfig
+from clawchat_gateway.group_message_coalescer import GroupMessageCoalescer
+from clawchat_gateway.group_settings import EffectiveSettings, GroupSettings, GroupSettingsCache
+from clawchat_gateway.storage import ClawChatStore
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _store(tmp_path) -> ClawChatStore:
+    s = ClawChatStore(tmp_path / "clawchat.sqlite")
+    s.initialize()
+    return s
+
+
+def _insert_msg(store: ClawChatStore, *, account_id: str, chat_id: str, message_id: str, text: str, created_at: int) -> None:
+    """Insert a raw inbound message row (bypassing claim_message_once dedup)."""
+    conn = sqlite3.connect(store.db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO clawchat_messages(
+              platform, account_id, kind, direction, event_type,
+              chat_id, message_id, text, raw_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("hermes", account_id, "message", "inbound", "message.send",
+             chat_id, message_id, text, None, created_at),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Storage test: list_recent_group_messages returns last N, oldest-first
+# ---------------------------------------------------------------------------
+
+def test_list_recent_group_messages_last_n_oldest_first(tmp_path):
+    """Insert 15 messages with increasing created_at, expect last 10, [0]=='t5', [9]=='t14'."""
+    store = _store(tmp_path)
+    account_id = "usr_agent"
+    chat_id = "cnv_group"
+    for i in range(15):
+        _insert_msg(
+            store,
+            account_id=account_id,
+            chat_id=chat_id,
+            message_id=f"msg_{i}",
+            text=f"t{i}",
+            created_at=1000 + i,
+        )
+    result = store.list_recent_group_messages(account_id, chat_id, 10)
+    assert len(result) == 10, f"Expected 10, got {len(result)}"
+    assert result[0]["text"] == "t5", f"Expected t5 at [0], got {result[0]['text']}"
+    assert result[9]["text"] == "t14", f"Expected t14 at [9], got {result[9]['text']}"
+
+
+def test_list_recent_group_messages_returns_fewer_when_not_enough(tmp_path):
+    """When fewer than N messages exist, returns all of them."""
+    store = _store(tmp_path)
+    for i in range(3):
+        _insert_msg(store, account_id="usr_a", chat_id="cnv_g", message_id=f"m{i}", text=f"t{i}", created_at=1000 + i)
+    result = store.list_recent_group_messages("usr_a", "cnv_g", 10)
+    assert len(result) == 3
+    assert result[0]["text"] == "t0"
+    assert result[2]["text"] == "t2"
+
+
+def test_list_recent_group_messages_scoped_to_account_and_chat(tmp_path):
+    """Messages from another account or chat must not appear."""
+    store = _store(tmp_path)
+    _insert_msg(store, account_id="usr_a", chat_id="cnv_g", message_id="m1", text="mine", created_at=1000)
+    _insert_msg(store, account_id="usr_b", chat_id="cnv_g", message_id="m2", text="other_account", created_at=1001)
+    _insert_msg(store, account_id="usr_a", chat_id="cnv_other", message_id="m3", text="other_chat", created_at=1002)
+    result = store.list_recent_group_messages("usr_a", "cnv_g", 10)
+    assert len(result) == 1
+    assert result[0]["text"] == "mine"
+
+
+def test_list_recent_group_messages_empty_when_no_rows(tmp_path):
+    store = _store(tmp_path)
+    result = store.list_recent_group_messages("usr_a", "cnv_g", 10)
+    assert result == []
+
+
+def test_list_recent_group_messages_row_shape(tmp_path):
+    """Each row dict has at least message_id, text, created_at."""
+    store = _store(tmp_path)
+    _insert_msg(store, account_id="usr_a", chat_id="cnv_g", message_id="msg_shape", text="hello", created_at=9999)
+    result = store.list_recent_group_messages("usr_a", "cnv_g", 10)
+    assert len(result) == 1
+    row = result[0]
+    assert row["message_id"] == "msg_shape"
+    assert row["text"] == "hello"
+    assert row["created_at"] == 9999
+
+
+# ---------------------------------------------------------------------------
+# Adapter fakes (mirrored from test_adapter_dispatch.py)
+# ---------------------------------------------------------------------------
+
+class _FakeConnection:
+    def __init__(self):
+        self.frames = []
+        self.send_results = []
+
+    async def send_frame(self, frame, **kwargs):
+        self.frames.append((frame, kwargs))
+        if self.send_results:
+            return self.send_results.pop(0)
+        return True
+
+
+class _FakeStore:
+    """Fake store that also supports list_recent_group_messages."""
+
+    def __init__(self, recent_rows: list[dict] | None = None):
+        self.claimed: list[dict] = []
+        self._recent_rows = recent_rows or []
+
+    def claim_message_once(self, **kwargs):
+        self.claimed.append(kwargs)
+        return True
+
+    def update_message_by_identity(self, **kwargs):
+        pass
+
+    def insert_message(self, **kwargs):
+        pass
+
+    def get_activation_conversation(self, **_kwargs):
+        return None
+
+    def list_recent_group_messages(self, account_id: str, chat_id: str, limit: int) -> list[dict]:
+        return list(self._recent_rows)
+
+
+def _load_adapter_class(monkeypatch):
+    gateway = ModuleType("gateway")
+    gateway_config = ModuleType("gateway.config")
+    gateway_platforms = ModuleType("gateway.platforms")
+    gateway_base = ModuleType("gateway.platforms.base")
+
+    class _Platform(str):
+        CLAWCHAT = "clawchat"
+
+    class _BasePlatformAdapter:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class _MessageEvent:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _MessageType:
+        TEXT = "text"
+
+    class _SendResult:
+        def __init__(self, success, error=None, message_id=None):
+            self.success = success
+            self.error = error
+            self.message_id = message_id
+
+    gateway_config.Platform = _Platform
+    gateway_base.BasePlatformAdapter = _BasePlatformAdapter
+    gateway_base.MessageEvent = _MessageEvent
+    gateway_base.MessageType = _MessageType
+    gateway_base.SendResult = _SendResult
+    gateway_platforms.base = gateway_base
+    gateway.config = gateway_config
+    gateway.platforms = gateway_platforms
+
+    monkeypatch.setitem(sys.modules, "gateway", gateway)
+    monkeypatch.setitem(sys.modules, "gateway.config", gateway_config)
+    monkeypatch.setitem(sys.modules, "gateway.platforms", gateway_platforms)
+    monkeypatch.setitem(sys.modules, "gateway.platforms.base", gateway_base)
+
+    import clawchat_gateway.adapter as adapter_module
+    return importlib.reload(adapter_module).ClawChatAdapter
+
+
+class _FakeSource:
+    pass
+
+
+def _make_adapter(monkeypatch, *, extra=None, recent_rows: list[dict] | None = None, group_settings: list[GroupSettings] | None = None):
+    ClawChatAdapter = _load_adapter_class(monkeypatch)
+    adapter = ClawChatAdapter.__new__(ClawChatAdapter)
+    adapter._clawchat_config = ClawChatConfig.from_platform_config(
+        SimpleNamespace(
+            extra={
+                "websocket_url": "wss://example.test/ws",
+                "token": "token",
+                "user_id": "usr_agent",
+                **(extra or {}),
+            }
+        )
+    )
+    adapter._connection = _FakeConnection()
+    adapter._store = _FakeStore(recent_rows=recent_rows)
+    adapter._memory_root = None
+    adapter._inbound_window = {}
+    adapter._known_chat_types = {}
+    adapter._owner_approval_routes = {}
+    adapter._active_runs_by_id = {}
+    adapter._active_chat_runs = {}
+    adapter._completed_run_ids = set()
+    adapter._completed_run_order = []
+    adapter._recent_emits = OrderedDict()
+    adapter._reply_preview_by_message_id = {}
+    adapter._reply_preview_order = []
+    adapter._conversation_metadata_versions = {}
+    adapter._plugin_report_tasks = set()
+    adapter._profile_sync_tasks = set()
+    adapter._run_counter = 0
+
+    # Stub out Hermes infrastructure methods that _handle_inbound needs
+    adapter.build_source = lambda **_kw: _FakeSource()
+    adapter._map_source_chat_type = lambda ct: ct
+    adapter._extract_reply_fields = lambda reply: (None, None)
+    adapter._session_user_id_for_inbound = lambda inbound: inbound.sender_id
+    adapter._compose_channel_prompt_parts = lambda inbound: []
+    adapter._render_channel_prompt_parts = lambda parts: None
+    adapter.write_llm_context_snapshot = lambda **_kw: None
+
+    async def _fake_download_inbound_media(inbound):
+        return []
+
+    adapter._download_inbound_media = _fake_download_inbound_media
+
+    dispatched_events: list[Any] = []
+
+    async def _fake_handle_message(event):
+        dispatched_events.append(event)
+
+    adapter.handle_message = _fake_handle_message
+
+    dispatched_inbound: list[Any] = []
+
+    async def _fake_handle_inbound(inbound):
+        dispatched_inbound.append(inbound)
+
+    adapter._group_message_coalescer = GroupMessageCoalescer(
+        idle_seconds=10.0,
+        max_wait_seconds=30.0,
+        dispatch=_fake_handle_inbound,
+    )
+    adapter._group_settings_cache = GroupSettingsCache()
+    if group_settings:
+        adapter._group_settings_cache.apply_fetched(group_settings)
+
+    adapter._dispatched_inbound = dispatched_inbound
+    adapter._dispatched_events = dispatched_events
+    return adapter
+
+
+def _mention_frame(
+    *,
+    chat_id: str = "cnv_group",
+    sender_id: str = "usr_sender",
+    text: str = "@Agent hi",
+    message_id: str = "msg_mention",
+) -> dict:
+    return {
+        "version": "2",
+        "event": "message.send",
+        "chat_id": chat_id,
+        "chat_type": "group",
+        "sender": {"id": sender_id, "nick_name": "Sender"},
+        "payload": {
+            "message_id": message_id,
+            "message": {
+                "body": {
+                    "fragments": [
+                        {"kind": "mention", "user_id": "usr_agent", "display": "Agent"},
+                        {"kind": "text", "text": " hi"},
+                    ]
+                },
+                "context": {
+                    "mentions": [{"kind": "mention", "user_id": "usr_agent", "display": "Agent"}],
+                    "reply": None,
+                },
+            },
+        },
+    }
+
+
+def _group_frame(
+    *,
+    chat_id: str = "cnv_group",
+    sender_id: str = "usr_other",
+    text: str = "background msg",
+    message_id: str = "msg_bg",
+) -> dict:
+    return {
+        "version": "2",
+        "event": "message.send",
+        "chat_id": chat_id,
+        "chat_type": "group",
+        "sender": {"id": sender_id, "nick_name": "Other"},
+        "payload": {
+            "message_id": message_id,
+            "message": {
+                "body": {"fragments": [{"kind": "text", "text": text}]},
+                "context": {"mentions": [], "reply": None},
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Adapter test 1: mention turn prepends prior context
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mention_turn_prepends_prior_context(monkeypatch):
+    """A @-mention in a group turn causes prior context to be prepended to event.text."""
+    recent_rows = [
+        {"message_id": "msg_prior_1", "text": "first prior message", "created_at": 100},
+        {"message_id": "msg_prior_2", "text": "second prior message", "created_at": 200},
+    ]
+    adapter = _make_adapter(monkeypatch, recent_rows=recent_rows)
+
+    # Directly test _handle_inbound with a pre-built group batch (mention)
+    from clawchat_gateway.inbound import InboundMessage
+    inbound = InboundMessage(
+        chat_id="cnv_group",
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="@Agent hi",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": [_mention_frame()],
+        },
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1, "Should dispatch exactly one event"
+    event = adapter._dispatched_events[0]
+    # The event text must contain the prior context before the current messages
+    assert "first prior message" in event.text, "Prior context row 1 must appear in event text"
+    assert "second prior message" in event.text, "Prior context row 2 must appear in event text"
+    # Context must appear BEFORE the current turn text
+    idx_prior = event.text.find("first prior message")
+    idx_mention = event.text.find("@Agent")
+    assert idx_prior < idx_mention, "Prior context must come before the current mention text"
+
+
+# ---------------------------------------------------------------------------
+# Adapter test 2: multi-message batch dedup — no duplicates from batched messages
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mention_batch_no_duplicate_batched_messages_in_context(monkeypatch):
+    """
+    Coalesced batch of 2 messages + mention: all batched message_ids are in
+    list_recent_group_messages results → NONE of them duplicated in prior context.
+
+    This is the bug the OpenClaw task hit: if dedupe only checked the triggering
+    message_id (not ALL constituent IDs), the earlier batched messages would appear
+    twice (once in the turn body, once in prior context).
+    """
+    # The batch will contain msg_bg (background) + msg_mention (mention)
+    bg_id = "msg_bg"
+    mention_id = "msg_mention"
+
+    # Recent rows include BOTH batched message_ids (simulating they were stored before dispatch)
+    recent_rows = [
+        {"message_id": "msg_old_1", "text": "old message 1", "created_at": 50},
+        {"message_id": bg_id, "text": "background msg", "created_at": 100},  # in batch → must be deduped
+        {"message_id": mention_id, "text": "@Agent hi", "created_at": 200},  # in batch → must be deduped
+    ]
+    adapter = _make_adapter(monkeypatch, recent_rows=recent_rows)
+
+    from clawchat_gateway.inbound import InboundMessage
+    # Build a coalesced batch with two messages
+    inbound = InboundMessage(
+        chat_id="cnv_group",
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="ClawChat group messages:\n[message 1] Other: background msg\n[message 2] Sender: @Agent hi",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": [_group_frame(), _mention_frame()],
+        },
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1
+    event = adapter._dispatched_events[0]
+
+    # Old message must appear in context (not in batch)
+    assert "old message 1" in event.text, "Non-batched prior context row must appear"
+
+    # Count occurrences: "background msg" must appear exactly ONCE (in the turn body, not repeated in context)
+    bg_count = event.text.count("background msg")
+    assert bg_count == 1, (
+        f"'background msg' appeared {bg_count} times — batched message must NOT be duplicated in prior context"
+    )
+
+    # Count occurrences: "@Agent hi" must appear exactly ONCE
+    mention_count = event.text.count("@Agent hi")
+    assert mention_count == 1, (
+        f"'@Agent hi' appeared {mention_count} times — batched message must NOT be duplicated in prior context"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter test 3: non-mention group turn does NOT prepend context
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_non_mention_group_turn_does_not_prepend_context(monkeypatch):
+    """A non-mention group turn must NOT prepend prior context (no storage query)."""
+    recent_rows = [
+        {"message_id": "msg_prior", "text": "prior message", "created_at": 100},
+    ]
+    adapter = _make_adapter(monkeypatch, recent_rows=recent_rows)
+
+    from clawchat_gateway.inbound import InboundMessage
+    inbound = InboundMessage(
+        chat_id="cnv_group",
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="just chatting",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": [_group_frame()],
+        },
+        was_mentioned=False,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1
+    event = adapter._dispatched_events[0]
+    assert "prior message" not in event.text, "Non-mention must NOT inject prior context"

--- a/tests/test_context_on_mention.py
+++ b/tests/test_context_on_mention.py
@@ -435,6 +435,59 @@ async def test_mention_batch_no_duplicate_batched_messages_in_context(monkeypatc
 
 
 # ---------------------------------------------------------------------------
+# Regression: persist path and read path must agree on account_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mention_prior_context_uses_persist_account_id(monkeypatch, tmp_path):
+    """Persist path writes account_id="default"; the mention read path must use the
+    SAME account_id, not the paired ClawChat user_id.
+
+    Regression for the bug where _build_mention_prior_context_text queried with
+    self._account_id() (the ClawChat user_id) while _record_message /
+    _claim_message_once persist with account_id="default", so the read matched 0
+    rows in any paired adapter and prior context was never prepended.
+
+    Uses the REAL ClawChatStore (not the account_id-ignoring fake) so the mismatch
+    surfaces.
+    """
+    # Real store, populated exactly as the persist path does: account_id="default".
+    store = _store(tmp_path)
+    chat_id = "cnv_group"
+    _insert_msg(store, account_id="default", chat_id=chat_id, message_id="msg_prior_1", text="first prior message", created_at=100)
+    _insert_msg(store, account_id="default", chat_id=chat_id, message_id="msg_prior_2", text="second prior message", created_at=200)
+
+    # Paired adapter: user_id is a real usr_* value, NOT "default".
+    adapter = _make_adapter(monkeypatch)
+    adapter._store = store
+    assert adapter._account_id() == "usr_agent", "precondition: paired user_id != 'default'"
+
+    from clawchat_gateway.inbound import InboundMessage
+    inbound = InboundMessage(
+        chat_id=chat_id,
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="@Agent hi",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": [_mention_frame()],
+        },
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1
+    event = adapter._dispatched_events[0]
+    assert "first prior message" in event.text, (
+        "prior context (persisted under account_id='default') must be returned to the "
+        "mention read path"
+    )
+    assert "second prior message" in event.text
+
+
+# ---------------------------------------------------------------------------
 # Adapter test 3: non-mention group turn does NOT prepend context
 # ---------------------------------------------------------------------------
 

--- a/tests/test_context_on_mention.py
+++ b/tests/test_context_on_mention.py
@@ -487,6 +487,91 @@ async def test_mention_prior_context_uses_persist_account_id(monkeypatch, tmp_pa
     assert "second prior message" in event.text
 
 
+@pytest.mark.asyncio
+async def test_mention_batch_fetches_enough_rows_to_cover_batch(monkeypatch, tmp_path):
+    """The current batch is persisted BEFORE prior-context fetch runs.
+
+    A coalesced batch of K messages is written to clawchat_messages with the
+    most-recent timestamps, so they dominate any ``LIMIT N`` fetch.  If the
+    fetch only asks for MENTION_CONTEXT_N rows, the batch's own rows consume the
+    window and genuine prior context is starved (a full N-message batch returns
+    zero prior rows).  The fetch must request batch_size + MENTION_CONTEXT_N rows
+    so that, after removing the batch's ids, MENTION_CONTEXT_N prior rows remain.
+
+    Uses the REAL ClawChatStore so the LIMIT clause is exercised.
+    """
+    adapter = _make_adapter(monkeypatch)  # also installs the gateway import stub
+    from clawchat_gateway.adapter import MENTION_CONTEXT_N
+
+    store = _store(tmp_path)
+    chat_id = "cnv_group"
+
+    # MENTION_CONTEXT_N genuine prior messages (older timestamps).
+    for i in range(MENTION_CONTEXT_N):
+        _insert_msg(
+            store,
+            account_id="default",
+            chat_id=chat_id,
+            message_id=f"msg_prior_{i}",
+            text=f"prior message {i}",
+            created_at=100 + i,
+        )
+
+    # A full coalesced batch of MENTION_CONTEXT_N messages, persisted AFTER the
+    # prior rows (newest timestamps) — exactly what the persist path does before
+    # dispatch.
+    batch_frames = []
+    for j in range(MENTION_CONTEXT_N):
+        mid = f"msg_batch_{j}"
+        _insert_msg(
+            store,
+            account_id="default",
+            chat_id=chat_id,
+            message_id=mid,
+            text=f"batch message {j}",
+            created_at=1000 + j,
+        )
+        batch_frames.append(_group_frame(message_id=mid, text=f"batch message {j}"))
+    # The triggering mention is the last message of the batch.
+    batch_frames.append(_mention_frame(message_id="msg_batch_mention"))
+    _insert_msg(
+        store,
+        account_id="default",
+        chat_id=chat_id,
+        message_id="msg_batch_mention",
+        text="@Agent hi",
+        created_at=2000,
+    )
+
+    adapter._store = store
+
+    from clawchat_gateway.inbound import InboundMessage
+    inbound = InboundMessage(
+        chat_id=chat_id,
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="@Agent hi",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": batch_frames,
+        },
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1
+    event = adapter._dispatched_events[0]
+
+    # All MENTION_CONTEXT_N genuine prior rows must survive after the batch's own
+    # rows are deduped out — the starved fetch would have returned zero of them.
+    for i in range(MENTION_CONTEXT_N):
+        assert f"prior message {i}" in event.text, (
+            f"prior message {i} missing — batch rows starved the prior-context fetch"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Adapter test 3: non-mention group turn does NOT prepend context
 # ---------------------------------------------------------------------------

--- a/tests/test_context_on_mention.py
+++ b/tests/test_context_on_mention.py
@@ -270,7 +270,7 @@ def _make_adapter(monkeypatch, *, extra=None, recent_rows: list[dict] | None = N
     )
     adapter._group_settings_cache = GroupSettingsCache()
     if group_settings:
-        adapter._group_settings_cache.apply_fetched(group_settings)
+        adapter._group_settings_cache.apply_fetched(group_settings, sequence=1)
 
     adapter._dispatched_inbound = dispatched_inbound
     adapter._dispatched_events = dispatched_events
@@ -432,6 +432,81 @@ async def test_mention_batch_no_duplicate_batched_messages_in_context(monkeypatc
     assert mention_count == 1, (
         f"'@Agent hi' appeared {mention_count} times — batched message must NOT be duplicated in prior context"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue 1: a group slash command must NOT get prior-context prepended.
+#
+# A group slash command carries a structured mention (to clear the reply-mode
+# gate) and is dispatched through _handle_inbound with was_mentioned=True. The
+# UNCONDITIONAL prior-context prepend used to push the leading slash off the
+# start of the turn ("prior text\n.../help @Agent"), so Hermes stopped seeing it
+# as a command. The slash must stay at the very start of the dispatched text.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_group_slash_command_not_prefixed_with_prior_context(monkeypatch):
+    """A group /command (mentioned) dispatches WITHOUT prior-context prepended."""
+    recent_rows = [
+        {"message_id": "msg_prior_1", "text": "first prior message", "created_at": 100},
+        {"message_id": "msg_prior_2", "text": "second prior message", "created_at": 200},
+    ]
+    adapter = _make_adapter(monkeypatch, recent_rows=recent_rows)
+
+    from clawchat_gateway.inbound import InboundMessage
+    # The group command-dispatch path forwards the RAW single-frame inbound (not a
+    # coalesced batch) with the slash leading and a structured mention present.
+    command_text = "/help @Agent"
+    inbound = InboundMessage(
+        chat_id="cnv_group",
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text=command_text,
+        raw_message=_mention_frame(text=command_text),
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    assert len(adapter._dispatched_events) == 1
+    event = adapter._dispatched_events[0]
+    # The slash command must remain the very first thing Hermes sees.
+    assert event.text.lstrip().startswith("/help"), (
+        f"slash command must stay at the start, got: {event.text!r}"
+    )
+    assert event.text == command_text, "command turn must NOT have prior context prepended"
+    assert "first prior message" not in event.text
+    assert "second prior message" not in event.text
+
+
+@pytest.mark.asyncio
+async def test_group_non_command_mention_still_prepends_prior_context(monkeypatch):
+    """Control: a normal (non-command) mention still gets prior context prepended."""
+    recent_rows = [
+        {"message_id": "msg_prior_1", "text": "first prior message", "created_at": 100},
+    ]
+    adapter = _make_adapter(monkeypatch, recent_rows=recent_rows)
+
+    from clawchat_gateway.inbound import InboundMessage
+    inbound = InboundMessage(
+        chat_id="cnv_group",
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text="@Agent what's up",
+        raw_message={
+            "clawchat_group_batch": True,
+            "messages": [_mention_frame(text="@Agent what's up")],
+        },
+        was_mentioned=True,
+    )
+
+    await adapter._handle_inbound(inbound)
+
+    event = adapter._dispatched_events[0]
+    assert "first prior message" in event.text, "non-command mention must still get prior context"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_group_message_coalescer.py
+++ b/tests/test_group_message_coalescer.py
@@ -1,0 +1,155 @@
+"""Tests for GroupMessageCoalescer per-chat idle override (Task 11 TDD).
+
+Tests the idle_seconds_override parameter added to enqueue().
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from clawchat_gateway.group_message_coalescer import GroupMessageCoalescer
+from clawchat_gateway.inbound import InboundMessage
+
+
+def _msg(chat_id: str = "cnv_1", text: str = "hello") -> InboundMessage:
+    return InboundMessage(
+        chat_id=chat_id,
+        chat_type="group",
+        sender_id="usr_sender",
+        sender_name="Sender",
+        text=text,
+        raw_message={},
+    )
+
+
+class _FakeClock:
+    """Controllable clock for asyncio.sleep."""
+
+    def __init__(self) -> None:
+        self._waiters: list[tuple[float, asyncio.Future[None]]] = []
+        self._now = 0.0
+
+    async def sleep(self, seconds: float) -> None:
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[None] = loop.create_future()
+        self._waiters.append((self._now + seconds, fut))
+        await fut
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+        done = []
+        remaining = []
+        for wake_at, fut in self._waiters:
+            if self._now >= wake_at:
+                if not fut.done():
+                    fut.set_result(None)
+                done.append((wake_at, fut))
+            else:
+                remaining.append((wake_at, fut))
+        self._waiters = remaining
+
+
+@pytest.mark.asyncio
+async def test_enqueue_uses_idle_seconds_override() -> None:
+    """With idle_seconds_override=3, the batch should flush after 3s not the default 10s."""
+    clock = _FakeClock()
+    dispatched: list[InboundMessage] = []
+
+    async def dispatch(msg: InboundMessage) -> None:
+        dispatched.append(msg)
+
+    coalescer = GroupMessageCoalescer(
+        idle_seconds=10.0,
+        max_wait_seconds=30.0,
+        dispatch=dispatch,
+        sleep=clock.sleep,
+    )
+
+    coalescer.enqueue(_msg(), idle_seconds_override=3.0)
+    await asyncio.sleep(0)  # let the task start and reach the sleep
+    assert dispatched == []
+
+    # advance 3 seconds — should flush
+    clock.advance(3.0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(dispatched) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_default_idle_without_override() -> None:
+    """Without override, the default idle_seconds (10) is used."""
+    clock = _FakeClock()
+    dispatched: list[InboundMessage] = []
+
+    async def dispatch(msg: InboundMessage) -> None:
+        dispatched.append(msg)
+
+    coalescer = GroupMessageCoalescer(
+        idle_seconds=10.0,
+        max_wait_seconds=30.0,
+        dispatch=dispatch,
+        sleep=clock.sleep,
+    )
+
+    coalescer.enqueue(_msg())
+    await asyncio.sleep(0)  # let the task start and reach the sleep
+    assert dispatched == []
+
+    # advance only 3s — should NOT flush (default is 10s)
+    clock.advance(3.0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert dispatched == []
+
+    # advance to 10s total — should flush
+    clock.advance(7.0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(dispatched) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_idle_override_resets_on_new_message() -> None:
+    """Each enqueue resets the idle timer with the latest override."""
+    clock = _FakeClock()
+    dispatched: list[InboundMessage] = []
+
+    async def dispatch(msg: InboundMessage) -> None:
+        dispatched.append(msg)
+
+    coalescer = GroupMessageCoalescer(
+        idle_seconds=10.0,
+        max_wait_seconds=30.0,
+        dispatch=dispatch,
+        sleep=clock.sleep,
+    )
+
+    coalescer.enqueue(_msg(text="first"), idle_seconds_override=5.0)
+    await asyncio.sleep(0)  # let task start
+    clock.advance(3.0)
+    await asyncio.sleep(0)
+
+    # Second message resets timer with same override
+    coalescer.enqueue(_msg(text="second"), idle_seconds_override=5.0)
+    await asyncio.sleep(0)  # let new task start
+    await asyncio.sleep(0)
+
+    # 4s total elapsed since second message reset, not yet 5s — no flush
+    clock.advance(4.0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert dispatched == []
+
+    # Now 5s since reset — flush
+    clock.advance(1.0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(dispatched) == 1
+    # The merged message should include both
+    assert "first" in dispatched[0].text or "second" in dispatched[0].text

--- a/tests/test_group_settings.py
+++ b/tests/test_group_settings.py
@@ -1,11 +1,21 @@
-"""Tests for GroupSettingsCache and get_my_group_settings (Task 10 TDD).
+"""Tests for GroupSettingsCache and get_my_group_settings.
 
-Three cache cases (mirrors Task 6 / TS plugin parity):
-  1. Backend row overrides static fallback.
-  2. Stale (lower version) row is ignored.
-  3. Unknown chat falls back to static_fallback.
+Sequence-ordered, authoritative-vs-not cache semantics (mirrors the OpenClaw
+plugin's ``GroupSettingsCache`` parity, Task 6 + group-governance migration):
 
-Plus a thin parse test for get_my_group_settings 404 -> [].
+  1. An authoritative full pull REPLACES the cache (prunes vanished rows).
+  2. Cross-pull ordering is by a monotonic fetch SEQUENCE assigned at the call
+     site — a pull whose sequence <= the last applied one is dropped wholesale
+     (this gates EMPTY pulls too: a stale "clear all" can never overtake a newer
+     snapshot). ``version`` is only an in-snapshot tiebreaker.
+  3. An authoritative HTTP 200 with an EMPTY list means "zero overrides" and
+     CLEARS the cache.
+  4. A non-authoritative outcome (404 / endpoint-absent / non-2xx / network
+     error) is a NO-OP at the call site — it must never reach ``apply_fetched``.
+  5. Unknown chat falls back to ``static_fallback``.
+
+Plus parse tests for ``get_my_group_settings`` distinguishing an authoritative
+200 (incl. 200-empty) from a non-authoritative 404.
 """
 
 from __future__ import annotations
@@ -24,38 +34,38 @@ STATIC = EffectiveSettings(muted=False, reply_mode="all", batch_delay_seconds=10
 
 
 # ---------------------------------------------------------------------------
-# Cache: three canonical cases
+# Cache: canonical cases (sequence-ordered)
 # ---------------------------------------------------------------------------
 
 
 def test_backend_overrides_static() -> None:
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 2)])
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 2)], sequence=1)
     assert c.effective("c1", STATIC) == EffectiveSettings(True, "mention", 30)
 
 
-def test_ignores_stale_version() -> None:
+def test_ignores_stale_sequence() -> None:
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "all", 10, 5)])
-    # older version must NOT overwrite
-    c.apply_fetched([GroupSettings("c1", False, "all", 10, 3)])
+    c.apply_fetched([GroupSettings("c1", True, "all", 10, 5)], sequence=2)
+    # A later-arriving pull tagged with an older sequence must be dropped wholesale.
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 3)], sequence=1)
     assert c.effective("c1", STATIC).muted is True
 
 
-def test_ignores_strictly_lower_version_boundary() -> None:
-    """version 4 < 5 => ignored (boundary: strict-less-than is ignored)."""
+def test_ignores_equal_sequence() -> None:
+    """A pull with sequence == last-applied is a re-delivery and is dropped."""
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)])
-    c.apply_fetched([GroupSettings("c1", False, "all", 10, 4)])
+    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)], sequence=3)
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 9)], sequence=3)
     assert c.effective("c1", STATIC).muted is True
     assert c.effective("c1", STATIC).reply_mode == "mention"
 
 
-def test_accepts_equal_version() -> None:
-    """version == cached => accepted (>= semantics)."""
+def test_accepts_higher_sequence() -> None:
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)])
-    c.apply_fetched([GroupSettings("c1", False, "all", 10, 5)])
+    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)], sequence=1)
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 1)], sequence=2)
+    # Newer sequence wins regardless of row version (version is not a cross-pull guard).
     assert c.effective("c1", STATIC).muted is False
 
 
@@ -66,54 +76,84 @@ def test_unknown_chat_falls_back() -> None:
 
 def test_multiple_conversations_independent() -> None:
     c = GroupSettingsCache()
-    c.apply_fetched([
-        GroupSettings("c1", True, "mention", 30, 1),
-        GroupSettings("c2", False, "all", 5, 1),
-    ])
+    c.apply_fetched(
+        [
+            GroupSettings("c1", True, "mention", 30, 1),
+            GroupSettings("c2", False, "all", 5, 1),
+        ],
+        sequence=1,
+    )
     assert c.effective("c1", STATIC) == EffectiveSettings(True, "mention", 30)
     assert c.effective("c2", STATIC) == EffectiveSettings(False, "all", 5)
     assert c.effective("c3", STATIC) == STATIC
 
 
-def test_apply_fetched_empty_list_is_noop() -> None:
-    """Empty fetch is treated as a no-op (404 / no-endpoint safety), NOT a wipe."""
+def test_authoritative_empty_pull_clears_cache() -> None:
+    """An authoritative 200 with an EMPTY list means "zero overrides" => clear all.
+
+    This replaces the old ``test_apply_fetched_empty_list_is_noop``: the 404 /
+    no-endpoint safety now lives at the CALL SITE (non-authoritative outcomes
+    never reach ``apply_fetched``), so an empty list that *does* reach the cache
+    is an authoritative "all overrides cleared" and must prune.
+    """
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 3)])
-    c.apply_fetched([])
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 3)], sequence=1)
+    c.apply_fetched([], sequence=2)
+    assert c.effective("c1", STATIC) == STATIC, "authoritative empty pull must clear"
+
+
+def test_stale_empty_pull_does_not_wipe_newer_snapshot() -> None:
+    """A late EMPTY pull with a LOWER sequence must not wipe a newer snapshot."""
+    c = GroupSettingsCache()
+    # Newer non-empty snapshot applied first (higher sequence).
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 5)], sequence=2)
+    # A stale empty "clear all" lands late with a lower sequence — ignored.
+    c.apply_fetched([], sequence=1)
     assert c.effective("c1", STATIC).muted is True
 
 
 def test_full_fetch_clears_rows_absent_from_fresh_fetch() -> None:
-    """A non-empty full fetch is a replacement set: a conversation omitted from the
-    fresh fetch must fall back to static (not keep its stale cached override)."""
+    """A full pull is a replacement set: a conversation omitted from the fresh
+    pull must fall back to static (not keep its stale cached override)."""
     c = GroupSettingsCache()
-    c.apply_fetched([
-        GroupSettings("c1", True, "mention", 30, 1),
-        GroupSettings("c2", True, "all", 10, 1),
-    ])
-    # Fresh fetch no longer includes c1 (e.g. agent left that group, row deleted).
-    c.apply_fetched([GroupSettings("c2", True, "all", 10, 2)])
+    c.apply_fetched(
+        [
+            GroupSettings("c1", True, "mention", 30, 1),
+            GroupSettings("c2", True, "all", 10, 1),
+        ],
+        sequence=1,
+    )
+    # Fresh pull no longer includes c1 (e.g. agent left that group, row deleted).
+    c.apply_fetched([GroupSettings("c2", True, "all", 10, 2)], sequence=2)
     assert c.effective("c1", STATIC) == STATIC, "omitted row must be cleared"
     assert c.effective("c2", STATIC).muted is True
 
 
-def test_full_fetch_replacement_preserves_version_monotonicity() -> None:
-    """A row whose fetched version is strictly older than the cached one is kept
-    (guards a refresh racing behind a newer config-changed signal)."""
+def test_stale_nonempty_pull_does_not_roll_back() -> None:
+    """An out-of-order older non-empty snapshot (lower sequence) is dropped."""
     c = GroupSettingsCache()
-    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 5)])
-    # Stale fetch (older version) for c1 alongside a fresh c2.
-    c.apply_fetched([
-        GroupSettings("c1", False, "all", 10, 3),
-        GroupSettings("c2", False, "all", 5, 1),
-    ])
-    assert c.effective("c1", STATIC).muted is True, "stale version must not overwrite"
-    assert c.effective("c1", STATIC).reply_mode == "mention"
-    assert c.effective("c2", STATIC) == EffectiveSettings(False, "all", 5)
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 5)], sequence=3)
+    c.apply_fetched([GroupSettings("c2", True, "all", 20, 3)], sequence=2)
+    assert c.effective("c1", STATIC).muted is True
+    assert c.effective("c2", STATIC) == STATIC
+
+
+def test_in_snapshot_version_tiebreaker() -> None:
+    """Within ONE snapshot a repeated conversation keeps the highest version."""
+    c = GroupSettingsCache()
+    c.apply_fetched(
+        [
+            GroupSettings("c1", False, "all", 10, 1),
+            GroupSettings("c1", True, "mention", 30, 5),
+            GroupSettings("c1", False, "all", 10, 3),
+        ],
+        sequence=1,
+    )
+    assert c.effective("c1", STATIC) == EffectiveSettings(True, "mention", 30)
 
 
 # ---------------------------------------------------------------------------
-# get_my_group_settings: 404 -> [] and happy-path parse
+# get_my_group_settings: authoritative-vs-not parse
 # ---------------------------------------------------------------------------
 
 
@@ -154,7 +194,8 @@ def _patch_urlopen_status(monkeypatch, status: int, payload: dict | None = None)
 
 
 @pytest.mark.asyncio
-async def test_get_my_group_settings_404_returns_empty(monkeypatch) -> None:
+async def test_get_my_group_settings_404_is_non_authoritative(monkeypatch) -> None:
+    """HTTP 404 (older backend, no endpoint) => non-authoritative no-op result."""
     from clawchat_gateway.api_client import ClawChatApiClient
 
     _patch_urlopen_status(monkeypatch, 404)
@@ -162,7 +203,23 @@ async def test_get_my_group_settings_404_returns_empty(monkeypatch) -> None:
         base_url="https://api.test", token="tok", device_id="dev-1"
     )
     result = await client.get_my_group_settings()
-    assert result == []
+    assert result.authoritative is False
+    assert result.rows == []
+
+
+@pytest.mark.asyncio
+async def test_get_my_group_settings_200_empty_is_authoritative(monkeypatch) -> None:
+    """HTTP 200 with an empty list => authoritative "zero overrides"."""
+    from clawchat_gateway.api_client import ClawChatApiClient
+
+    payload = {"code": 0, "data": {"settings": []}, "msg": ""}
+    _patch_urlopen_status(monkeypatch, 200, payload)
+    client = ClawChatApiClient(
+        base_url="https://api.test", token="tok", device_id="dev-1"
+    )
+    result = await client.get_my_group_settings()
+    assert result.authoritative is True
+    assert result.rows == []
 
 
 @pytest.mark.asyncio
@@ -198,11 +255,13 @@ async def test_get_my_group_settings_parses_rows(monkeypatch) -> None:
         base_url="https://api.test", token="tok", device_id="dev-1"
     )
     result = await client.get_my_group_settings()
-    assert len(result) == 2
-    assert result[0].conversation_id == "grp_abc"
-    assert result[0].muted is True
-    assert result[0].reply_mode == "mention"
-    assert result[0].batch_delay_seconds == 15
-    assert result[0].version == 7
-    assert result[1].conversation_id == "grp_def"
-    assert result[1].muted is False
+    assert result.authoritative is True
+    rows = result.rows
+    assert len(rows) == 2
+    assert rows[0].conversation_id == "grp_abc"
+    assert rows[0].muted is True
+    assert rows[0].reply_mode == "mention"
+    assert rows[0].batch_delay_seconds == 15
+    assert rows[0].version == 7
+    assert rows[1].conversation_id == "grp_def"
+    assert rows[1].muted is False

--- a/tests/test_group_settings.py
+++ b/tests/test_group_settings.py
@@ -76,10 +76,40 @@ def test_multiple_conversations_independent() -> None:
 
 
 def test_apply_fetched_empty_list_is_noop() -> None:
+    """Empty fetch is treated as a no-op (404 / no-endpoint safety), NOT a wipe."""
     c = GroupSettingsCache()
     c.apply_fetched([GroupSettings("c1", True, "mention", 30, 3)])
     c.apply_fetched([])
     assert c.effective("c1", STATIC).muted is True
+
+
+def test_full_fetch_clears_rows_absent_from_fresh_fetch() -> None:
+    """A non-empty full fetch is a replacement set: a conversation omitted from the
+    fresh fetch must fall back to static (not keep its stale cached override)."""
+    c = GroupSettingsCache()
+    c.apply_fetched([
+        GroupSettings("c1", True, "mention", 30, 1),
+        GroupSettings("c2", True, "all", 10, 1),
+    ])
+    # Fresh fetch no longer includes c1 (e.g. agent left that group, row deleted).
+    c.apply_fetched([GroupSettings("c2", True, "all", 10, 2)])
+    assert c.effective("c1", STATIC) == STATIC, "omitted row must be cleared"
+    assert c.effective("c2", STATIC).muted is True
+
+
+def test_full_fetch_replacement_preserves_version_monotonicity() -> None:
+    """A row whose fetched version is strictly older than the cached one is kept
+    (guards a refresh racing behind a newer config-changed signal)."""
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 5)])
+    # Stale fetch (older version) for c1 alongside a fresh c2.
+    c.apply_fetched([
+        GroupSettings("c1", False, "all", 10, 3),
+        GroupSettings("c2", False, "all", 5, 1),
+    ])
+    assert c.effective("c1", STATIC).muted is True, "stale version must not overwrite"
+    assert c.effective("c1", STATIC).reply_mode == "mention"
+    assert c.effective("c2", STATIC) == EffectiveSettings(False, "all", 5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_group_settings.py
+++ b/tests/test_group_settings.py
@@ -1,0 +1,178 @@
+"""Tests for GroupSettingsCache and get_my_group_settings (Task 10 TDD).
+
+Three cache cases (mirrors Task 6 / TS plugin parity):
+  1. Backend row overrides static fallback.
+  2. Stale (lower version) row is ignored.
+  3. Unknown chat falls back to static_fallback.
+
+Plus a thin parse test for get_my_group_settings 404 -> [].
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawchat_gateway.group_settings import (
+    EffectiveSettings,
+    GroupSettings,
+    GroupSettingsCache,
+)
+
+STATIC = EffectiveSettings(muted=False, reply_mode="all", batch_delay_seconds=10)
+
+
+# ---------------------------------------------------------------------------
+# Cache: three canonical cases
+# ---------------------------------------------------------------------------
+
+
+def test_backend_overrides_static() -> None:
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 2)])
+    assert c.effective("c1", STATIC) == EffectiveSettings(True, "mention", 30)
+
+
+def test_ignores_stale_version() -> None:
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "all", 10, 5)])
+    # older version must NOT overwrite
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 3)])
+    assert c.effective("c1", STATIC).muted is True
+
+
+def test_ignores_strictly_lower_version_boundary() -> None:
+    """version 4 < 5 => ignored (boundary: strict-less-than is ignored)."""
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)])
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 4)])
+    assert c.effective("c1", STATIC).muted is True
+    assert c.effective("c1", STATIC).reply_mode == "mention"
+
+
+def test_accepts_equal_version() -> None:
+    """version == cached => accepted (>= semantics)."""
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "mention", 20, 5)])
+    c.apply_fetched([GroupSettings("c1", False, "all", 10, 5)])
+    assert c.effective("c1", STATIC).muted is False
+
+
+def test_unknown_chat_falls_back() -> None:
+    c = GroupSettingsCache()
+    assert c.effective("c1", STATIC) == STATIC
+
+
+def test_multiple_conversations_independent() -> None:
+    c = GroupSettingsCache()
+    c.apply_fetched([
+        GroupSettings("c1", True, "mention", 30, 1),
+        GroupSettings("c2", False, "all", 5, 1),
+    ])
+    assert c.effective("c1", STATIC) == EffectiveSettings(True, "mention", 30)
+    assert c.effective("c2", STATIC) == EffectiveSettings(False, "all", 5)
+    assert c.effective("c3", STATIC) == STATIC
+
+
+def test_apply_fetched_empty_list_is_noop() -> None:
+    c = GroupSettingsCache()
+    c.apply_fetched([GroupSettings("c1", True, "mention", 30, 3)])
+    c.apply_fetched([])
+    assert c.effective("c1", STATIC).muted is True
+
+
+# ---------------------------------------------------------------------------
+# get_my_group_settings: 404 -> [] and happy-path parse
+# ---------------------------------------------------------------------------
+
+
+def _patch_urlopen_status(monkeypatch, status: int, payload: dict | None = None):
+    """Monkey-patch api_client.urlopen to return a fake HTTP response."""
+    import clawchat_gateway.api_client as api_client_mod
+    from urllib.error import HTTPError
+    import io
+
+    if status == 404:
+        def fake_urlopen(request, timeout=None):
+            raise HTTPError(
+                url=request.full_url,
+                code=404,
+                msg="Not Found",
+                hdrs={},  # type: ignore[arg-type]
+                fp=io.BytesIO(b'{"code":404,"msg":"not found","data":{}}'),
+            )
+    else:
+        raw = json.dumps(payload).encode("utf-8")
+
+        class _FakeResp:
+            status = 200
+
+            def read(self):
+                return raw
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def fake_urlopen(request, timeout=None):
+            return _FakeResp()
+
+    monkeypatch.setattr(api_client_mod, "urlopen", fake_urlopen)
+
+
+@pytest.mark.asyncio
+async def test_get_my_group_settings_404_returns_empty(monkeypatch) -> None:
+    from clawchat_gateway.api_client import ClawChatApiClient
+
+    _patch_urlopen_status(monkeypatch, 404)
+    client = ClawChatApiClient(
+        base_url="https://api.test", token="tok", device_id="dev-1"
+    )
+    result = await client.get_my_group_settings()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_my_group_settings_parses_rows(monkeypatch) -> None:
+    from clawchat_gateway.api_client import ClawChatApiClient
+
+    payload = {
+        "code": 0,
+        "data": {
+            "settings": [
+                {
+                    "conversation_id": "grp_abc",
+                    "agent_id": "agt_xyz",
+                    "muted": True,
+                    "reply_mode": "mention",
+                    "batch_delay_seconds": 15,
+                    "version": 7,
+                },
+                {
+                    "conversation_id": "grp_def",
+                    "agent_id": "agt_xyz",
+                    "muted": False,
+                    "reply_mode": "all",
+                    "batch_delay_seconds": 5,
+                    "version": 2,
+                },
+            ]
+        },
+        "msg": "",
+    }
+    _patch_urlopen_status(monkeypatch, 200, payload)
+    client = ClawChatApiClient(
+        base_url="https://api.test", token="tok", device_id="dev-1"
+    )
+    result = await client.get_my_group_settings()
+    assert len(result) == 2
+    assert result[0].conversation_id == "grp_abc"
+    assert result[0].muted is True
+    assert result[0].reply_mode == "mention"
+    assert result[0].batch_delay_seconds == 15
+    assert result[0].version == 7
+    assert result[1].conversation_id == "grp_def"
+    assert result[1].muted is False

--- a/tests/test_group_settings.py
+++ b/tests/test_group_settings.py
@@ -265,3 +265,57 @@ async def test_get_my_group_settings_parses_rows(monkeypatch) -> None:
     assert rows[0].version == 7
     assert rows[1].conversation_id == "grp_def"
     assert rows[1].muted is False
+
+
+def _patch_urlopen_auth(monkeypatch, status: int):
+    """Monkey-patch api_client.urlopen to raise an HTTP auth error (401/403)."""
+    import io
+
+    import clawchat_gateway.api_client as api_client_mod
+    from urllib.error import HTTPError
+
+    def fake_urlopen(request, timeout=None):
+        raise HTTPError(
+            url=request.full_url,
+            code=status,
+            msg="Unauthorized",
+            hdrs={},  # type: ignore[arg-type]
+            fp=io.BytesIO(b'{"code":401,"msg":"token expired","data":{}}'),
+        )
+
+    monkeypatch.setattr(api_client_mod, "urlopen", fake_urlopen)
+
+
+@pytest.mark.parametrize("status", [401, 403])
+@pytest.mark.asyncio
+async def test_get_my_group_settings_auth_error_propagates(monkeypatch, status: int) -> None:
+    """A 401/403 must PROPAGATE (kind=="auth") so the reactive token-refresh
+    path runs — it must NOT be swallowed into a silent non-authoritative no-op,
+    which would leave settings unloadable until some unrelated REST call
+    refreshes the token."""
+    from clawchat_gateway.api_client import ClawChatApiClient, ClawChatApiError
+
+    _patch_urlopen_auth(monkeypatch, status)
+    client = ClawChatApiClient(base_url="https://api.test", token="tok", device_id="dev-1")
+    with pytest.raises(ClawChatApiError) as excinfo:
+        await client.get_my_group_settings()
+    assert excinfo.value.kind == "auth"
+    assert excinfo.value.status == status
+
+
+@pytest.mark.asyncio
+async def test_get_my_group_settings_network_error_is_non_authoritative(monkeypatch) -> None:
+    """A network error (non-auth, non-2xx) stays a non-authoritative no-op so
+    the cache is preserved."""
+    import clawchat_gateway.api_client as api_client_mod
+    from clawchat_gateway.api_client import ClawChatApiClient
+    from urllib.error import URLError
+
+    def fake_urlopen(request, timeout=None):
+        raise URLError("connection reset")
+
+    monkeypatch.setattr(api_client_mod, "urlopen", fake_urlopen)
+    client = ClawChatApiClient(base_url="https://api.test", token="tok", device_id="dev-1")
+    result = await client.get_my_group_settings()
+    assert result.authoritative is False
+    assert result.rows == []

--- a/tests/test_no_reply.py
+++ b/tests/test_no_reply.py
@@ -1,5 +1,5 @@
 import pytest
-from clawchat_gateway.no_reply import is_no_reply_token
+from clawchat_gateway.no_reply import is_no_reply_token, is_no_reply_token_prefix
 
 ACCEPT = [
     "<clawchat:no-reply/>",
@@ -29,3 +29,44 @@ def test_accept(s):
 @pytest.mark.parametrize("s", REJECT)
 def test_reject(s):
     assert is_no_reply_token(s) is False
+
+
+# A streaming first chunk that is a strict prefix of *any* accepted variant
+# (bracket / case / spacing / silent) must be recognized so the suppression
+# guard holds it instead of leaking the token to chat.
+PREFIX_ACCEPT = [
+    "<",
+    "<clawchat",
+    "<clawchat:no",
+    "[clawchat",
+    "[clawchat:no-reply",  # missing closing bracket -> still a prefix
+    "{clawchat:sil",
+    "<CLAWCHAT:NO",
+    "<CLAWCHAT:NO-REPLY",
+    "  <clawchat:no-rep",  # surrounding whitespace tolerated like the matcher
+    "clawchat:no",
+    "clawchat:silen",
+]
+
+# Complete tokens are NOT prefixes (they are handled by is_no_reply_token),
+# and obviously-normal text is not a prefix either.
+PREFIX_REJECT = [
+    "",
+    "   ",
+    "<clawchat:no-reply/>",  # complete -> not a (strict) prefix
+    "[clawchat:silent]",  # complete -> not a (strict) prefix
+    "sure",
+    "hello there",
+    "<div>",
+    "<clawchat:something",  # diverges from both no-reply and silent
+]
+
+
+@pytest.mark.parametrize("s", PREFIX_ACCEPT)
+def test_prefix_accept(s):
+    assert is_no_reply_token_prefix(s) is True
+
+
+@pytest.mark.parametrize("s", PREFIX_REJECT)
+def test_prefix_reject(s):
+    assert is_no_reply_token_prefix(s) is False

--- a/tests/test_no_reply.py
+++ b/tests/test_no_reply.py
@@ -1,0 +1,31 @@
+import pytest
+from clawchat_gateway.no_reply import is_no_reply_token
+
+ACCEPT = [
+    "<clawchat:no-reply/>",
+    "<clawchat:no-reply>",
+    "[clawchat:no-reply]",
+    "{clawchat:no-reply}",
+    "  <clawchat:no-reply/>  ",
+    "<CLAWCHAT:NO-REPLY/>",
+    "clawchat:no-reply",
+    "<clawchat:silent/>",
+    "[clawchat:silent]",
+]
+
+REJECT = [
+    "sure, replying",
+    "<clawchat:no-reply/> and here is more",
+    "the no-reply token is <clawchat:no-reply/>",
+    "clawchat: no-reply please",
+]
+
+
+@pytest.mark.parametrize("s", ACCEPT)
+def test_accept(s):
+    assert is_no_reply_token(s) is True
+
+
+@pytest.mark.parametrize("s", REJECT)
+def test_reject(s):
+    assert is_no_reply_token(s) is False

--- a/tests/test_reply_mode_surface_removed.py
+++ b/tests/test_reply_mode_surface_removed.py
@@ -1640,6 +1640,46 @@ async def test_empty_response_notice_is_suppressed_on_run_complete(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_streamed_bracket_no_reply_token_is_suppressed(monkeypatch):
+    """A streamed bracket/case variant of the no-reply token must not leak.
+
+    The first partial chunk ``[clawchat`` is a prefix of the accepted bracket
+    variant ``[clawchat:no-reply]``; the streaming guard must hold it (not set
+    run.last_text) so the final-detection suppression still fires when the full
+    token arrives.  Regression for a guard that only recognized prefixes of the
+    canonical ``<clawchat:no-reply/>``.
+    """
+    adapter = _adapter(monkeypatch)
+
+    result = await adapter.send(
+        "chat-1",
+        " ▉",
+        metadata={"notify": True, "chat_type": "direct"},
+    )
+
+    # First partial chunk: prefix of [clawchat:no-reply] — must be held.
+    edit_result = await adapter.edit_message(
+        "chat-1",
+        result.message_id,
+        "[clawchat",
+    )
+    assert edit_result.success is True
+    assert _sent_events(adapter) == []
+
+    final_result = await adapter.edit_message(
+        "chat-1",
+        result.message_id,
+        "[clawchat:no-reply]",
+        finalize=True,
+    )
+
+    assert final_result.success is True
+    assert _sent_events(adapter) == []
+    assert result.message_id not in adapter._active_runs_by_id
+    assert result.message_id in adapter._completed_run_ids
+
+
+@pytest.mark.asyncio
 async def test_group_text_that_resembles_tool_progress_is_not_filtered_by_adapter(monkeypatch):
     adapter = _adapter(monkeypatch)
 

--- a/tests/test_reply_mode_surface_removed.py
+++ b/tests/test_reply_mode_surface_removed.py
@@ -2398,7 +2398,13 @@ def _group_envelope(
     }
 
 
-def test_group_mention_mode_requires_context_mentions_for_dispatch() -> None:
+def test_group_parse_inbound_message_no_longer_filters_mention_mode() -> None:
+    # Task 11: the static pre-persist mention-mode drop was removed from
+    # parse_inbound_message. Filtering is now dynamic in the adapter
+    # (after claim_message_once), using the backend GroupSettingsCache.
+    # parse_inbound_message now always returns the message regardless of
+    # fragment mentions vs context_mentions; was_mentioned is derived solely
+    # from context_mentions.
     config = ClawChatConfig(
         websocket_url="wss://example.test/ws",
         user_id="usr_agent",
@@ -2416,7 +2422,9 @@ def test_group_mention_mode_requires_context_mentions_for_dispatch() -> None:
         config,
     )
 
-    assert inbound is None
+    # Message is now parsed (not dropped); was_mentioned=False because context_mentions=[]
+    assert inbound is not None
+    assert inbound.was_mentioned is False
 
 
 def test_context_mentions_drive_dispatch_and_fragment_display_drives_llm_context() -> None:


### PR DESCRIPTION
## Summary

Adds per-group agent governance to the Hermes ClawChat plugin: agents fetch and cache per-group settings and honor them at runtime (mute, batch window, reply mode, @-mention context).

## Changes
- feat: fetch + cache per-group agent settings, re-pull on signal/reconnect
- feat: per-chat mute gate, dynamic batch window, reply-mode from backend settings
- fix(task-11): add static-mention fallback test + tighten _flush_after_idle type
- feat: prepend last-N group message context when agent is @-mentioned
- fix: tolerate bracket/case/spacing variants of clawchat:no-reply token

🤖 Generated with [Claude Code](https://claude.com/claude-code)