### PR TITLE
feat: liveware agent web-app binding (hermes plugin)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -382,6 +382,14 @@ def _register_skill(ctx) -> None:
         description="ClawChat profiles, friends, moments, and media.",
     )
 
+    liveware_skill = _plugin_dir() / "skills" / "liveware-app" / "SKILL.md"
+    if liveware_skill.exists():
+        register_skill(
+            "liveware-app",
+            liveware_skill,
+            description="Expose a local web service via liveware and register it to ClawChat.",
+        )
+
 
 def _platform_value(platform) -> str:
     value = getattr(platform, "value", platform)

--- a/clawchat_gateway/api_client.py
+++ b/clawchat_gateway/api_client.py
@@ -215,6 +215,29 @@ class ClawChatApiClient:
             raise ClawChatApiError("validation", "friend_user_id is required")
         return await self._call_json("DELETE", f"/v1/friendships/{friend_user_id}")
 
+    async def register_app(self, *, name: str, app_id: str, url: str) -> dict:
+        if not name.strip():
+            raise ClawChatApiError("validation", "name is required")
+        if not app_id.strip():
+            raise ClawChatApiError("validation", "app_id is required")
+        if not url.strip():
+            raise ClawChatApiError("validation", "url is required")
+        payload = {"name": name, "app_id": app_id, "url": url}
+        return await self._call_json(
+            "POST",
+            "/v1/agents/me/apps",
+            body=json.dumps(payload).encode("utf-8"),
+            extra_headers={"content-type": "application/json"},
+        )
+
+    async def list_apps(self) -> dict:
+        return await self._call_json("GET", "/v1/agents/me/apps")
+
+    async def unregister_app(self, app_id: str) -> dict:
+        if not app_id.strip():
+            raise ClawChatApiError("validation", "app_id is required")
+        return await self._call_json("DELETE", f"/v1/agents/me/apps/{app_id}")
+
     async def search_users(self, *, q: str = "", limit: int | None = None) -> dict:
         params: dict[str, str | int] = {}
         if q:

--- a/clawchat_gateway/plugin_tools.py
+++ b/clawchat_gateway/plugin_tools.py
@@ -574,6 +574,55 @@ async def handle_clawchat_upload_avatar_image(args, **kw):
     return _tool_result(result)
 
 
+async def handle_clawchat_register_app(args, **kw):
+    task_id = kw.get("task_id") or "default"
+    logger.info("clawchat_register_app start task_id=%s", task_id)
+    from clawchat_gateway import tools
+
+    result = await _recorded_tool_call(
+        "clawchat_register_app",
+        args,
+        _account_id_from_kwargs(kw),
+        lambda: tools.register_app(
+            name=str(args.get("name", "")),
+            app_id=str(args.get("appId", "") or args.get("app_id", "")),
+            url=str(args.get("url", "")),
+        ),
+    )
+    logger.info("clawchat_register_app done task_id=%s", task_id)
+    return _tool_result(result)
+
+
+async def handle_clawchat_list_apps(args, **kw):
+    task_id = kw.get("task_id") or "default"
+    logger.info("clawchat_list_apps start task_id=%s", task_id)
+    from clawchat_gateway import tools
+
+    result = await _recorded_tool_call(
+        "clawchat_list_apps",
+        args,
+        _account_id_from_kwargs(kw),
+        lambda: tools.list_apps(),
+    )
+    logger.info("clawchat_list_apps done task_id=%s", task_id)
+    return _tool_result(result)
+
+
+async def handle_clawchat_unregister_app(args, **kw):
+    task_id = kw.get("task_id") or "default"
+    logger.info("clawchat_unregister_app start task_id=%s", task_id)
+    from clawchat_gateway import tools
+
+    result = await _recorded_tool_call(
+        "clawchat_unregister_app",
+        args,
+        _account_id_from_kwargs(kw),
+        lambda: tools.unregister_app(str(args.get("appId", "") or args.get("app_id", ""))),
+    )
+    logger.info("clawchat_unregister_app done task_id=%s", task_id)
+    return _tool_result(result)
+
+
 _DIRECT_TOOL_USE_INSTRUCTION = (
     "Use this registered ClawChat plugin tool directly. Do not use execute, shell commands, Python scripts, "
     "curl, handwritten API clients, generic fallback tools, or direct ClawChat HTTP calls "
@@ -1334,4 +1383,83 @@ def register_tools(ctx) -> None:
         is_async=True,
         description="Upload ClawChat Avatar Image",
         emoji="🖼️",
+    )
+
+    ctx.register_tool(
+        "clawchat_register_app",
+        "clawchat",
+        {
+            "name": "clawchat_register_app",
+            "description": _direct_tool_description(
+                "Register a liveware-tunneled web app to ClawChat so it shows in the owner's chat. "
+                "Call after `liveware tunnel bind` succeeds."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Human-readable app name shown on the launcher tile.",
+                    },
+                    "appId": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The liveware app id from `liveware app create`/`liveware app list`.",
+                    },
+                    "url": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The public tunnel URL from `liveware tunnel bind` (http/https).",
+                    },
+                },
+                "required": ["name", "appId", "url"],
+            },
+        },
+        handle_clawchat_register_app,
+        is_async=True,
+        description="Register liveware app",
+        emoji="A",
+    )
+
+    ctx.register_tool(
+        "clawchat_list_apps",
+        "clawchat",
+        {
+            "name": "clawchat_list_apps",
+            "description": _direct_tool_description(
+                "List the liveware web apps this agent has registered to ClawChat."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handle_clawchat_list_apps,
+        is_async=True,
+        description="List liveware apps",
+        emoji="A",
+    )
+
+    ctx.register_tool(
+        "clawchat_unregister_app",
+        "clawchat",
+        {
+            "name": "clawchat_unregister_app",
+            "description": _direct_tool_description(
+                "Unregister a previously registered liveware app from ClawChat."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "appId": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The liveware app id to unregister.",
+                    },
+                },
+                "required": ["appId"],
+            },
+        },
+        handle_clawchat_unregister_app,
+        is_async=True,
+        description="Unregister liveware app",
+        emoji="A",
     )

--- a/clawchat_gateway/plugin_tools.py
+++ b/clawchat_gateway/plugin_tools.py
@@ -623,6 +623,21 @@ async def handle_clawchat_unregister_app(args, **kw):
     return _tool_result(result)
 
 
+async def handle_clawchat_liveware_login(args, **kw):
+    task_id = kw.get("task_id") or "default"
+    logger.info("clawchat_liveware_login start task_id=%s", task_id)
+    from clawchat_gateway import tools
+
+    result = await _recorded_tool_call(
+        "clawchat_liveware_login",
+        args,
+        _account_id_from_kwargs(kw),
+        lambda: tools.liveware_login(),
+    )
+    logger.info("clawchat_liveware_login done task_id=%s ok=%s", task_id, result.get("ok") if isinstance(result, dict) else None)
+    return _tool_result(result)
+
+
 _DIRECT_TOOL_USE_INSTRUCTION = (
     "Use this registered ClawChat plugin tool directly. Do not use execute, shell commands, Python scripts, "
     "curl, handwritten API clients, generic fallback tools, or direct ClawChat HTTP calls "
@@ -1461,5 +1476,22 @@ def register_tools(ctx) -> None:
         handle_clawchat_unregister_app,
         is_async=True,
         description="Unregister liveware app",
+        emoji="A",
+    )
+
+    ctx.register_tool(
+        "clawchat_liveware_login",
+        "clawchat",
+        {
+            "name": "clawchat_liveware_login",
+            "description": _direct_tool_description(
+                "Log in to liveware using the agent's ClawChat account; the plugin resolves the token internally. "
+                "Call before liveware app/tunnel commands."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handle_clawchat_liveware_login,
+        is_async=True,
+        description="liveware login",
         emoji="A",
     )

--- a/clawchat_gateway/tools.py
+++ b/clawchat_gateway/tools.py
@@ -890,6 +890,50 @@ async def upload_avatar_image(file_path: str) -> dict[str, Any]:
         return _unknown_error(exc)
 
 
+async def register_app(name: str, app_id: str, url: str) -> dict[str, Any]:
+    if not isinstance(name, str) or not name.strip():
+        return _validation_error("name is required")
+    if not isinstance(app_id, str) or not app_id.strip():
+        return _validation_error("app_id is required")
+    if not isinstance(url, str) or not url.strip():
+        return _validation_error("url is required")
+    client, err = _build_client()
+    if err is not None:
+        return err
+    try:
+        return await client.register_app(name=name.strip(), app_id=app_id.strip(), url=url.strip())
+    except ClawChatApiError as exc:
+        return _api_error(exc)
+    except Exception as exc:  # noqa: BLE001
+        return _unknown_error(exc)
+
+
+async def list_apps() -> dict[str, Any]:
+    client, err = _build_client()
+    if err is not None:
+        return err
+    try:
+        return await client.list_apps()
+    except ClawChatApiError as exc:
+        return _api_error(exc)
+    except Exception as exc:  # noqa: BLE001
+        return _unknown_error(exc)
+
+
+async def unregister_app(app_id: str) -> dict[str, Any]:
+    if not isinstance(app_id, str) or not app_id.strip():
+        return _validation_error("app_id is required")
+    client, err = _build_client()
+    if err is not None:
+        return err
+    try:
+        return await client.unregister_app(app_id.strip())
+    except ClawChatApiError as exc:
+        return _api_error(exc)
+    except Exception as exc:  # noqa: BLE001
+        return _unknown_error(exc)
+
+
 async def upload_media_file(file_path: str) -> dict[str, Any]:
     path, err = _validate_upload_path(file_path)
     if err is not None:

--- a/clawchat_gateway/tools.py
+++ b/clawchat_gateway/tools.py
@@ -6,7 +6,9 @@ surface used by both Hermes tool registration and the profile CLI.
 
 from __future__ import annotations
 
+import asyncio
 import mimetypes
+import shutil
 from types import SimpleNamespace
 from pathlib import Path
 from typing import Any
@@ -959,3 +961,58 @@ async def upload_media_file(file_path: str) -> dict[str, Any]:
         return _api_error(exc)
     except Exception as exc:  # noqa: BLE001
         return _unknown_error(exc)
+
+
+_LIVEWARE_LOGIN_TIMEOUT = 30  # seconds
+
+
+async def liveware_login() -> dict[str, Any]:
+    """Log in to liveware using the agent's ClawChat account token.
+
+    The plugin resolves the token from the profile config and passes it to
+    the liveware CLI as --access-token. Call this before liveware app/tunnel
+    commands that require an authenticated session.
+
+    Security note: liveware's documented interface is --access-token, so the
+    token is in child argv briefly; env/stdin preferred if liveware supported
+    it. The token is NEVER logged, printed, or returned to callers — on error,
+    stderr/stdout are scrubbed with token replacement before returning.
+    """
+    try:
+        cfg = load_profile_config()
+    except ProfileConfigError as exc:
+        return _config_error(str(exc))
+
+    token = cfg.token
+
+    if shutil.which("liveware") is None:
+        return _validation_error("liveware CLI not found in PATH")
+
+    proc = await asyncio.create_subprocess_exec(
+        "liveware",
+        "login",
+        "--access-token",
+        token,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=_LIVEWARE_LOGIN_TIMEOUT)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+        return _validation_error("liveware login timed out")
+
+    if proc.returncode == 0:
+        return {"ok": True}
+
+    # Non-zero exit: scrub the token from all output before returning.
+    stderr_text = err.decode(errors="replace").replace(token, "***")
+    stdout_text = out.decode(errors="replace").replace(token, "***")
+    detail = (stderr_text or stdout_text).strip()
+    return {
+        "error": "subprocess",
+        "message": f"liveware login failed (exit {proc.returncode}): {detail}",
+    }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -34,3 +34,6 @@ provides_tools:
   - clawchat_memory_edit
   - clawchat_metadata_sync
   - clawchat_metadata_update
+  - clawchat_register_app
+  - clawchat_list_apps
+  - clawchat_unregister_app

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -37,3 +37,4 @@ provides_tools:
   - clawchat_register_app
   - clawchat_list_apps
   - clawchat_unregister_app
+  - clawchat_liveware_login

--- a/skills/liveware-app/SKILL.md
+++ b/skills/liveware-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: liveware-app
-description: Use when the user wants to expose this agent's local web service to the public internet via the liveware CLI and make it appear as an app in their ClawChat chat with this agent. Covers creating a liveware app, binding a tunnel to a local port, and registering the public URL to ClawChat.
+description: Use when the user wants to expose this agent's local web service to the public internet via the liveware CLI and make it appear as an app in their ClawChat chat with this agent. Covers logging in to liveware with the ClawChat account, creating a liveware app, binding a tunnel to a local port, and registering the public URL to ClawChat.
 ---
 
 # liveware App Hosting
@@ -13,16 +13,23 @@ ClawChat so it shows as an app tile in the owner's chat with this agent.
 1. Run `command -v liveware`. If it prints nothing (liveware is not installed), tell the
    user this environment does not support liveware app hosting and STOP. Do not attempt
    any further step or invent a URL.
-2. The ClawChat access token must be available as the `CLAWCHAT_TOKEN` environment
-   variable (the ClawChat plugin sets it). Never print the token.
+2. Authentication is handled by the ClawChat plugin, not by you. You log in by calling the
+   `clawchat_liveware_login` tool (step 1 below). Never read, print, or pass the ClawChat
+   access token yourself — the plugin holds it in its own credential store and never
+   exposes it to you or puts it in your context.
 
 ## Procedure
 
-1. **Login** (idempotent):
-   `liveware login --access-token "$CLAWCHAT_TOKEN"`
+1. **Login** (idempotent) — call the tool; do NOT run `liveware login` yourself:
+   `clawchat_liveware_login()`
+   The plugin resolves the ClawChat access token from its own credential store and runs
+   the liveware login internally. If it returns an error (liveware missing, ClawChat not
+   activated, or login failed), relay that error to the user and STOP.
 2. **Decide the app name and local port.** Ask the user for the local web service port if
-   not already known (e.g. the port the agent's own web server listens on). The bind target
-   is `http://127.0.0.1:<port>` (or the host:port the user specifies).
+   not already known (the port the agent's own web server listens on). Accept ONLY a plain
+   integer in the range 1–65535. Reject anything that is not purely numeric (e.g.
+   `3000; rm -rf /`) — never paste user-supplied text into a shell command. The bind target
+   is then exactly `http://127.0.0.1:<port>`.
 3. **List existing apps** to avoid duplicates and to recover ids:
    `liveware app list`
 4. **Create the app** (skip if reusing an existing one):
@@ -30,7 +37,9 @@ ClawChat so it shows as an app tile in the owner's chat with this agent.
    - This prints/returns the new **app id**. Capture it.
    - If liveware reports an app-limit / quota error, relay that error to the user verbatim
      and STOP. Do not delete other apps to make room.
-5. **Bind the tunnel** to the local service:
+5. **Bind the tunnel** to the local service. Use only the numeric `<port>` validated in
+   step 2, and pass the bind target as a single argument — do not wrap the command in extra
+   shell that interpolates unvalidated user input:
    `liveware tunnel bind <app id> http://127.0.0.1:<port>`
    - Capture the **public URL** liveware returns.
 6. **Register to ClawChat** so it appears in the owner's chat — call the tool, do NOT

--- a/skills/liveware-app/SKILL.md
+++ b/skills/liveware-app/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: liveware-app
+description: Use when the user wants to expose this agent's local web service to the public internet via the liveware CLI and make it appear as an app in their ClawChat chat with this agent. Covers creating a liveware app, binding a tunnel to a local port, and registering the public URL to ClawChat.
+---
+
+# liveware App Hosting
+
+Expose a local web service through a liveware tunnel and register the public URL to
+ClawChat so it shows as an app tile in the owner's chat with this agent.
+
+## Prerequisites — check first, stop if unmet
+
+1. Run `command -v liveware`. If it prints nothing (liveware is not installed), tell the
+   user this environment does not support liveware app hosting and STOP. Do not attempt
+   any further step or invent a URL.
+2. The ClawChat access token must be available as the `CLAWCHAT_TOKEN` environment
+   variable (the ClawChat plugin sets it). Never print the token.
+
+## Procedure
+
+1. **Login** (idempotent):
+   `liveware login --access-token "$CLAWCHAT_TOKEN"`
+2. **Decide the app name and local port.** Ask the user for the local web service port if
+   not already known (e.g. the port the agent's own web server listens on). The bind target
+   is `http://127.0.0.1:<port>` (or the host:port the user specifies).
+3. **List existing apps** to avoid duplicates and to recover ids:
+   `liveware app list`
+4. **Create the app** (skip if reusing an existing one):
+   `liveware app create "<app name>"`
+   - This prints/returns the new **app id**. Capture it.
+   - If liveware reports an app-limit / quota error, relay that error to the user verbatim
+     and STOP. Do not delete other apps to make room.
+5. **Bind the tunnel** to the local service:
+   `liveware tunnel bind <app id> http://127.0.0.1:<port>`
+   - Capture the **public URL** liveware returns.
+6. **Register to ClawChat** so it appears in the owner's chat — call the tool, do NOT
+   curl the API directly:
+   `clawchat_register_app(name="<app name>", appId="<app id>", url="<public URL>")`
+7. **Confirm** to the user: report the app name and public URL, and that it now appears in
+   their chat with this agent (open the「…」menu → the app tile).
+
+## Managing apps
+
+- To see what is registered to ClawChat: `clawchat_list_apps()`.
+- To remove one: `clawchat_unregister_app(appId="<app id>")` (this only removes it from
+  ClawChat; tear down the liveware tunnel/app with liveware's own commands separately).
+
+## Notes
+
+- Apps can be created up to liveware's account limit; surface its error rather than working
+  around it.
+- The registered web app opens in a sandboxed in-app browser on mobile with no ClawChat
+  login injected — do not assume the page can read the user's ClawChat identity.

--- a/tests/test_api_client_apps.py
+++ b/tests/test_api_client_apps.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawchat_gateway.api_client import ClawChatApiClient, ClawChatApiError
+
+
+def _client() -> ClawChatApiClient:
+    return ClawChatApiClient(base_url="https://api.example.com", token="t", device_id="d1")
+
+
+# ---------------------------------------------------------------------------
+# register_app
+# ---------------------------------------------------------------------------
+
+
+async def test_register_app_posts_payload(monkeypatch) -> None:
+    client = _client()
+    captured: dict = {}
+
+    async def fake_call(method, path, *, body=None, extra_headers=None):
+        captured.update(method=method, path=path, body=body)
+        return {"app": {"id": "agtapp_1", "app_id": "lw1", "name": "Dash", "url": "https://x"}}
+
+    monkeypatch.setattr(client, "_call_json", fake_call)
+    res = await client.register_app(name="Dash", app_id="lw1", url="https://x")
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/v1/agents/me/apps"
+    assert b"lw1" in captured["body"]
+    assert res["app"]["app_id"] == "lw1"
+
+
+async def test_register_app_body_contains_all_fields(monkeypatch) -> None:
+    client = _client()
+    captured: dict = {}
+
+    async def fake_call(method, path, *, body=None, extra_headers=None):
+        captured["body"] = body
+        return {"app": {}}
+
+    monkeypatch.setattr(client, "_call_json", fake_call)
+    await client.register_app(name="MyApp", app_id="lw2", url="https://example.com")
+
+    payload = json.loads(captured["body"])
+    assert payload == {"name": "MyApp", "app_id": "lw2", "url": "https://example.com"}
+
+
+async def test_register_app_validates_empty_name(monkeypatch) -> None:
+    client = _client()
+    with pytest.raises(ClawChatApiError) as exc_info:
+        await client.register_app(name="   ", app_id="lw1", url="https://x")
+    assert exc_info.value.kind == "validation"
+
+
+async def test_register_app_validates_empty_app_id(monkeypatch) -> None:
+    client = _client()
+    with pytest.raises(ClawChatApiError) as exc_info:
+        await client.register_app(name="Dash", app_id="", url="https://x")
+    assert exc_info.value.kind == "validation"
+
+
+async def test_register_app_validates_empty_url(monkeypatch) -> None:
+    client = _client()
+    with pytest.raises(ClawChatApiError) as exc_info:
+        await client.register_app(name="Dash", app_id="lw1", url="  ")
+    assert exc_info.value.kind == "validation"
+
+
+# ---------------------------------------------------------------------------
+# list_apps
+# ---------------------------------------------------------------------------
+
+
+async def test_list_apps_gets_correct_path(monkeypatch) -> None:
+    client = _client()
+    captured: dict = {}
+
+    async def fake_call(method, path, *, body=None, extra_headers=None):
+        captured.update(method=method, path=path)
+        return {"apps": []}
+
+    monkeypatch.setattr(client, "_call_json", fake_call)
+    res = await client.list_apps()
+
+    assert captured["method"] == "GET"
+    assert captured["path"] == "/v1/agents/me/apps"
+    assert res == {"apps": []}
+
+
+# ---------------------------------------------------------------------------
+# unregister_app
+# ---------------------------------------------------------------------------
+
+
+async def test_unregister_app_deletes_correct_path(monkeypatch) -> None:
+    client = _client()
+    captured: dict = {}
+
+    async def fake_call(method, path, *, body=None, extra_headers=None):
+        captured.update(method=method, path=path)
+        return {}
+
+    monkeypatch.setattr(client, "_call_json", fake_call)
+    await client.unregister_app("lw1")
+
+    assert captured["method"] == "DELETE"
+    assert captured["path"] == "/v1/agents/me/apps/lw1"
+
+
+async def test_unregister_app_validates_empty_app_id(monkeypatch) -> None:
+    client = _client()
+    with pytest.raises(ClawChatApiError) as exc_info:
+        await client.unregister_app("  ")
+    assert exc_info.value.kind == "validation"

--- a/tests/test_app_tools.py
+++ b/tests/test_app_tools.py
@@ -1,0 +1,193 @@
+"""Tests for register_app / list_apps / unregister_app tool wrappers and handlers."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clawchat_gateway import plugin_tools, tools
+
+
+class AppClient:
+    """Minimal stub mirroring ClawChatApiClient app methods."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    async def register_app(self, *, name: str, app_id: str, url: str) -> dict:
+        self.calls.append(("register", {"name": name, "app_id": app_id, "url": url}))
+        return {"app": {"id": "agtapp_1", "app_id": app_id, "name": name, "url": url}}
+
+    async def list_apps(self) -> dict:
+        self.calls.append(("list",))
+        return {"apps": [{"id": "agtapp_1", "app_id": "lw1", "name": "Dash", "url": "https://x"}]}
+
+    async def unregister_app(self, app_id: str) -> dict:
+        self.calls.append(("unregister", app_id))
+        return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# tools.py wrapper — validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_app_wrapper_validates_empty_name(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.register_app(name="", app_id="lw1", url="https://x")
+    assert res.get("error") == "validation"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_register_app_wrapper_validates_empty_app_id(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.register_app(name="Dash", app_id="", url="https://x")
+    assert res.get("error") == "validation"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_register_app_wrapper_validates_empty_url(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.register_app(name="Dash", app_id="lw1", url="  ")
+    assert res.get("error") == "validation"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_unregister_app_wrapper_validates_empty_app_id(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.unregister_app(app_id="")
+    assert res.get("error") == "validation"
+    assert client.calls == []
+
+
+# ---------------------------------------------------------------------------
+# tools.py wrapper — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_app_wrapper_calls_client(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.register_app(name="Dash", app_id="lw1", url="https://x")
+    assert res == {"app": {"id": "agtapp_1", "app_id": "lw1", "name": "Dash", "url": "https://x"}}
+    assert client.calls == [("register", {"name": "Dash", "app_id": "lw1", "url": "https://x"})]
+
+
+@pytest.mark.asyncio
+async def test_list_apps_wrapper_calls_client(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.list_apps()
+    assert "apps" in res
+    assert client.calls == [("list",)]
+
+
+@pytest.mark.asyncio
+async def test_unregister_app_wrapper_calls_client(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    res = await tools.unregister_app(app_id="lw1")
+    assert res == {"ok": True}
+    assert client.calls == [("unregister", "lw1")]
+
+
+# ---------------------------------------------------------------------------
+# plugin_tools.py handlers — tolerate both appId and app_id keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_register_app_accepts_appId(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    result = await plugin_tools.handle_clawchat_register_app(
+        {"name": "Dash", "appId": "lw1", "url": "https://x"}
+    )
+    payload = json.loads(result)
+    assert payload["app"]["app_id"] == "lw1"
+
+
+@pytest.mark.asyncio
+async def test_handle_register_app_accepts_app_id(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    result = await plugin_tools.handle_clawchat_register_app(
+        {"name": "Dash", "app_id": "lw2", "url": "https://x"}
+    )
+    payload = json.loads(result)
+    assert payload["app"]["app_id"] == "lw2"
+
+
+@pytest.mark.asyncio
+async def test_handle_list_apps_returns_json(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    result = await plugin_tools.handle_clawchat_list_apps({})
+    payload = json.loads(result)
+    assert "apps" in payload
+
+
+@pytest.mark.asyncio
+async def test_handle_unregister_app_accepts_appId(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    result = await plugin_tools.handle_clawchat_unregister_app({"appId": "lw1"})
+    payload = json.loads(result)
+    assert payload == {"ok": True}
+    assert client.calls == [("unregister", "lw1")]
+
+
+@pytest.mark.asyncio
+async def test_handle_unregister_app_accepts_app_id(monkeypatch):
+    client = AppClient()
+    monkeypatch.setattr(tools, "_build_client", lambda: (client, None))
+
+    result = await plugin_tools.handle_clawchat_unregister_app({"app_id": "lw2"})
+    payload = json.loads(result)
+    assert payload == {"ok": True}
+    assert client.calls == [("unregister", "lw2")]
+
+
+# ---------------------------------------------------------------------------
+# register_tools — schema registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_tools_includes_app_tool_schemas():
+    registered: dict[str, dict] = {}
+
+    class Ctx:
+        def register_tool(self, name, _namespace, schema, handler, **_kwargs):
+            registered[name] = {"schema": schema, "handler": handler}
+
+    plugin_tools.register_tools(Ctx())
+
+    assert set(registered) >= {
+        "clawchat_register_app",
+        "clawchat_list_apps",
+        "clawchat_unregister_app",
+    }
+    reg_schema = registered["clawchat_register_app"]["schema"]
+    assert set(reg_schema["parameters"]["required"]) == {"name", "appId", "url"}
+    unreg_schema = registered["clawchat_unregister_app"]["schema"]
+    assert unreg_schema["parameters"]["required"] == ["appId"]

--- a/tests/test_liveware_login.py
+++ b/tests/test_liveware_login.py
@@ -1,0 +1,160 @@
+"""Tests for clawchat_liveware_login tool and handler (TDD)."""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clawchat_gateway import plugin_tools, tools
+from clawchat_gateway.profile import ProfileConfigError
+
+
+# ---------------------------------------------------------------------------
+# tools.liveware_login — unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_liveware_login_no_cli_returns_error():
+    """liveware CLI not in PATH → error envelope with descriptive message."""
+    with (
+        patch("clawchat_gateway.tools.load_profile_config") as mock_cfg,
+        patch("shutil.which", return_value=None),
+    ):
+        mock_cfg.return_value = SimpleNamespace(token="tok123")
+        res = await tools.liveware_login()
+
+    assert res.get("error") is not None
+    assert "liveware CLI not found in PATH" in res.get("message", "")
+    # Token must never appear in result
+    assert "tok123" not in json.dumps(res)
+
+
+@pytest.mark.asyncio
+async def test_liveware_login_config_error_returns_config_envelope():
+    """ProfileConfigError → config error envelope."""
+    with patch("clawchat_gateway.tools.load_profile_config", side_effect=ProfileConfigError("missing token")):
+        res = await tools.liveware_login()
+
+    assert res.get("error") == "config"
+    assert "missing token" in res.get("message", "")
+
+
+@pytest.mark.asyncio
+async def test_liveware_login_success_returns_ok_without_token():
+    """exit 0 → {'ok': True} and token is NOT in the returned dict."""
+    token = "secret-bearer-token"
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.communicate = AsyncMock(return_value=(b"Logged in\n", b""))
+
+    with (
+        patch("clawchat_gateway.tools.load_profile_config") as mock_cfg,
+        patch("shutil.which", return_value="/usr/bin/liveware"),
+        patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake_proc)),
+    ):
+        mock_cfg.return_value = SimpleNamespace(token=token)
+        res = await tools.liveware_login()
+
+    assert res == {"ok": True}
+    # Security: token must never be in the returned value
+    assert token not in json.dumps(res)
+
+
+@pytest.mark.asyncio
+async def test_liveware_login_nonzero_exit_scrubs_token():
+    """Non-zero exit code → error envelope with scrubbed output (token replaced by ***)."""
+    token = "my-secret-token"
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = 1
+    fake_proc.communicate = AsyncMock(return_value=(b"", f"auth error: {token}".encode()))
+
+    with (
+        patch("clawchat_gateway.tools.load_profile_config") as mock_cfg,
+        patch("shutil.which", return_value="/usr/bin/liveware"),
+        patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake_proc)),
+    ):
+        mock_cfg.return_value = SimpleNamespace(token=token)
+        res = await tools.liveware_login()
+
+    assert res.get("error") is not None
+    result_json = json.dumps(res)
+    # Token must be scrubbed
+    assert token not in result_json
+    assert "***" in result_json
+
+
+@pytest.mark.asyncio
+async def test_liveware_login_timeout_returns_error():
+    """asyncio.TimeoutError → timeout error envelope; token not in result."""
+    token = "timeout-token"
+
+    async def _mock_communicate():
+        raise asyncio.TimeoutError
+
+    fake_proc = MagicMock()
+    fake_proc.kill = MagicMock()
+    fake_proc.communicate = _mock_communicate
+
+    with (
+        patch("clawchat_gateway.tools.load_profile_config") as mock_cfg,
+        patch("shutil.which", return_value="/usr/bin/liveware"),
+        patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=fake_proc)),
+    ):
+        mock_cfg.return_value = SimpleNamespace(token=token)
+        res = await tools.liveware_login()
+
+    assert res.get("error") is not None
+    assert token not in json.dumps(res)
+
+
+# ---------------------------------------------------------------------------
+# plugin_tools.handle_clawchat_liveware_login — handler test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_clawchat_liveware_login_success(monkeypatch):
+    """Handler delegates to tools.liveware_login and JSON-serialises the result."""
+    monkeypatch.setattr(tools, "liveware_login", AsyncMock(return_value={"ok": True}))
+
+    result = await plugin_tools.handle_clawchat_liveware_login({})
+    payload = json.loads(result)
+    assert payload == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_handle_clawchat_liveware_login_config_error(monkeypatch):
+    """Handler propagates config error envelope from tools.liveware_login."""
+    monkeypatch.setattr(
+        tools, "liveware_login", AsyncMock(return_value={"error": "config", "message": "missing token"})
+    )
+
+    result = await plugin_tools.handle_clawchat_liveware_login({})
+    payload = json.loads(result)
+    assert payload["error"] == "config"
+
+
+# ---------------------------------------------------------------------------
+# register_tools — registration check
+# ---------------------------------------------------------------------------
+
+
+def test_register_tools_includes_liveware_login():
+    registered: dict[str, dict] = {}
+
+    class Ctx:
+        def register_tool(self, name, _namespace, schema, handler, **_kwargs):
+            registered[name] = {"schema": schema, "handler": handler}
+
+    plugin_tools.register_tools(Ctx())
+
+    assert "clawchat_liveware_login" in registered
+    schema = registered["clawchat_liveware_login"]["schema"]
+    assert schema["name"] == "clawchat_liveware_login"
+    assert "description" in schema


### PR DESCRIPTION
## liveware agent web-app binding — Hermes plugin

Part of the cross-repo **liveware agent web-app binding** feature.

### What's here
- Three `ClawChatApiClient` methods → member-backend: `register_app`, `list_apps`, `unregister_app`.
- Three agent tools (`clawchat_register_app`, `clawchat_list_apps`, `clawchat_unregister_app`) wired through `tools.py` + `plugin_tools.py`, registered in `register_tools(ctx)` and listed in `plugin.yaml`. Handlers accept both `appId` and `app_id`.
- New bundled **`liveware-app` skill** (registered into the clawchat channel by default) that guards on `command -v liveware`, logs in with the ClawChat token, runs `liveware app create` / `app list` / `tunnel bind`, then registers the public URL via `clawchat_register_app`. Surfaces liveware's app-limit error verbatim; never injects auth into the agent's web page.

### Testing
Full suite green (400 passing); TDD; per-task + final whole-branch review passed. SKILL.md is byte-identical to the OpenClaw plugin's.

### Companion PRs
clawchat-member-backend (backend contract) · clawchat-plugin-openclaw · clawchat-frontend (mobile).
🤖 Generated with [Claude Code](https://claude.com/claude-code)
