### PR TITLE
feat(liveware): harden lifecycle and add development skill

### DIFF
--- a/clawchat_gateway/liveware_sample.py
+++ b/clawchat_gateway/liveware_sample.py
@@ -601,6 +601,31 @@ async def liveware_login(*, liveware_path, token: str, exec: ExecFn | None = Non
         raise LivewareSampleError(f"liveware login failed: {detail}")
 
 
+async def liveware_agent_is_running(
+    *, liveware_path, exec: ExecFn | None = None, timeout: float = _CLI_TIMEOUT,
+) -> bool:
+    """Return whether `liveware status` confirms the service is running.
+
+    Unknown output, unsupported older CLIs, and command failures deliberately
+    return False so callers retain the direct `liveware agent` fallback.
+    """
+    exec = exec or asyncio.create_subprocess_exec
+    try:
+        proc = await _maybe_await(exec(
+            liveware_path, "status",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        ))
+        out, err = await _communicate(proc, timeout, "liveware status")
+    except Exception:  # noqa: BLE001 — status is an optional compatibility probe
+        return False
+    if proc.returncode:
+        return False
+    output = " ".join(
+        part.decode(errors="replace") for part in (out or b"", err or b"")
+    )
+    return re.search(r"\bstatus:\s*running\b", output, re.IGNORECASE) is not None
+
+
 async def liveware_app_find_by_name(
     *, liveware_path, name: str, exec: ExecFn | None = None,
     log: "logging.Logger | None" = None, timeout: float = _CLI_TIMEOUT,
@@ -949,6 +974,10 @@ class LivewareSampleSupervisor:
             await liveware_login(liveware_path=path, token=token, exec=d.exec)
             if self._bail_if_stale(gen):
                 return
+            agent_running = await liveware_agent_is_running(
+                liveware_path=path, exec=d.exec)
+            if self._bail_if_stale(gen):
+                return
             # Reuse an app we already own before minting another one. `app
             # create` is not idempotent and nothing here ever reconciled against
             # the liveware side, so every bootstrap that died past this point (no
@@ -982,11 +1011,12 @@ class LivewareSampleSupervisor:
                 liveware_path=path, app_id=app_id, port=port, exec=d.exec)
             if self._bail_if_stale(gen):
                 return
-            self._tunnel, agent_drain = await start_tunnel_agent(
-                liveware_path=path, spawn=d.spawn)
-            self._spawn_task(agent_drain)
-            if self._bail_if_stale(gen):
-                return
+            if not agent_running:
+                self._tunnel, agent_drain = await start_tunnel_agent(
+                    liveware_path=path, spawn=d.spawn)
+                self._spawn_task(agent_drain)
+                if self._bail_if_stale(gen):
+                    return
             # From here on we do NOT bail before persisting: once register_app
             # has created the app card, a crash of either child must not abort
             # the flow before the row is written (H8 fix). register -> upsert
@@ -1000,7 +1030,8 @@ class LivewareSampleSupervisor:
                 app_name=LIVEWARE_SAMPLE_APP_NAME, port=port, public_url=public_url,
                 sample_version=version, status="active")
             self._watch_child(self._server)
-            self._watch_child(self._tunnel)
+            if self._tunnel is not None:
+                self._watch_child(self._tunnel)
         await self._deliver_intro()
         self._log.debug("liveware-sample bootstrap complete at %s", public_url)
 
@@ -1064,6 +1095,10 @@ class LivewareSampleSupervisor:
                     return
             else:
                 self._log.debug("liveware-sample no token; relaunch without re-login")
+            agent_running = await liveware_agent_is_running(
+                liveware_path=path, exec=d.exec)
+            if self._bail_if_stale(gen):
+                return
             # Kept AFTER the re-login above so the lookup runs against a CLI that
             # is actually authenticated: a pending row's app id came straight out
             # of `app create`'s parser and was never confirmed by the liveware
@@ -1084,11 +1119,12 @@ class LivewareSampleSupervisor:
                 liveware_path=path, app_id=app_id, port=port, exec=d.exec)
             if self._bail_if_stale(gen):
                 return
-            self._tunnel, agent_drain = await start_tunnel_agent(
-                liveware_path=path, spawn=d.spawn)
-            self._spawn_task(agent_drain)
-            if self._bail_if_stale(gen):
-                return
+            if not agent_running:
+                self._tunnel, agent_drain = await start_tunnel_agent(
+                    liveware_path=path, spawn=d.spawn)
+                self._spawn_task(agent_drain)
+                if self._bail_if_stale(gen):
+                    return
             # See _bootstrap: no bail between register/upsert (H8 fix) so a
             # crash of either child in this window can't orphan the row.
             # A pending row has never been registered with ClawChat (public_url is
@@ -1101,7 +1137,8 @@ class LivewareSampleSupervisor:
                 app_name=row.app_name, port=port, public_url=public_url,
                 sample_version=version, status="active")
             self._watch_child(self._server)
-            self._watch_child(self._tunnel)
+            if self._tunnel is not None:
+                self._watch_child(self._tunnel)
         if row.intro_sent == 0:
             await self._deliver_intro()
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,9 +120,10 @@ install.
 
 `MANIFEST.in` only ships `prompts/*.md`, and `[tool.setuptools.packages.find]`
 in `pyproject.toml` only includes the `clawchat_gateway*` package. The
-top-level `skills/` tree — all four bundled skill directories
+top-level `skills/` tree — all five bundled skill directories
 (`skills/clawchat-core/`, `skills/clawchat-liveware/`,
-`skills/clawchat-liveware-sample/`, `skills/clawchat-set-greeting/`, each with
+`skills/clawchat-liveware-dev/`, `skills/clawchat-liveware-sample/`,
+`skills/clawchat-set-greeting/`, each with
 a `SKILL.md`) **and**
 `skills/manifest.json` — lives outside that package and is not referenced by
 `MANIFEST.in` either, so none of it is included in a built wheel. A

--- a/docs/development.md
+++ b/docs/development.md
@@ -70,6 +70,44 @@ live Hermes process; the WebSocket transport
 (`clawchat_gateway/connection.py`) is the main piece that needs a fake
 or recorded server.
 
+## Install-scan regression
+
+Before publishing, scan the complete plugin checkout with the target Hermes
+version's Plugin Guard. Obtain a read-only host checkout as described in
+[Hermes source lookup](hermes-source-lookup.md), then run from this repo root
+with that host's Python environment:
+
+```bash
+PYTHONPATH=tmp/hermes python3 - <<'PY'
+from pathlib import Path
+from tools.plugin_guard import scan_plugin, should_allow_plugin_install
+
+result = scan_plugin(Path.cwd(), source="clawling/clawchat-plugin-hermes-agent")
+print(result.summary)
+allowed, reason = should_allow_plugin_install(result)
+print(reason)
+assert allowed is not False, reason
+PY
+```
+
+Use a checkout without local-only fixtures for release evidence (the scanner
+does not honor Git ignore rules). A caution verdict still requires reviewing
+the findings and confirming installation; this check only guards against a
+hard block, not all security risks. Keep scanning enabled.
+
+The September 2026 blocker was reproduced as 46 findings. Two documentation
+false positives caused the dangerous verdict: a relative-path explanation
+matched the DNS rule, and a rejected-input example matched the destructive
+command rule. The revised wording preserves path semantics and port validation.
+The same scanner reports caution with 44 findings afterward. Runtime code is
+unchanged; configuration-edit, subprocess, and other warnings remain visible.
+
+The bundled Hermes liveware skill has a same-version wording correction, with
+its local manifest digest updated. The independent install-cli skill source
+is not changed here: a later owner-approved dynamic update can restore that
+source's wording. Coordinate that source before publishing a new skills tag;
+do not advance the bundled version past the pinned official manifest.
+
 ## Live debugging against a Hermes process
 
 The supported development loop is:

--- a/docs/liveware-sample.md
+++ b/docs/liveware-sample.md
@@ -79,7 +79,7 @@ own. Only a genuine **opt-out** returns without scheduling anything:
    [Distribution](#distribution)) into `<sample_root>/app`.
 5. Start the local sample server (`start_sample_server`, default port
    `43110`; requires `node` on `PATH` — see the trigger conditions above).
-   No crash watcher is attached yet — see step 8. The supervisor also passes
+   No crash watcher is attached yet — see step 10. The supervisor also passes
    `--agent-id <cfg.user_id>` (`deps.resolve_agent_user_id`, wired in
    `adapter.py` from `self._clawchat_config.user_id`) so `server.mjs` can
    merge the agent's own ClawChat user id into `/state` and its SSE stream as
@@ -87,8 +87,14 @@ own. Only a genuine **opt-out** returns without scheduling anything:
    sample page uses that id to render a one-tap `clawchat://u/{id}?chat=1`
    back-to-chat deep link; with no id (older/relaunched-without-id cases) the
    page falls back to its plain-text guidance instead of the link.
-6. `liveware login` with the resolved token, then **reuse-or-create** the app:
-   `liveware app list` is parsed for an existing app already named
+6. `liveware login` with the resolved token, then run `liveware status`. If
+   status confirms `running`, the plugin treats that service as externally
+   managed and does not start, watch, or later stop a
+   second tunnel agent. A failed command, an older unsupported CLI, or any
+   status other than `running` retains the direct-start fallback described in
+   step 9.
+7. **Reuse or create** the app: `liveware app list` is parsed for an existing
+   app already named
    `Liveware Sample` (`liveware_app_find_by_name` → `find_app_id_by_name`) and
    its id is reused; only if nothing is found does `liveware app create` run.
    `app create` is not idempotent and nothing here ever reconciled against the
@@ -100,35 +106,33 @@ own. Only a genuine **opt-out** returns without scheduling anything:
    *wrong* id — its text-table branch requires the exact app name plus one
    id-looking token outside the name, where an id-looking token must carry a
    digit / `-` / `_` so a status word (`active`, `running`) cannot pass for an id.
-7. **Upsert the row with `status="pending"`** carrying the app id, the port, the
+8. **Upsert the row with `status="pending"`** carrying the app id, the port, the
    sample version and `public_url=None` — immediately, before anything below can
    fail. A failure anywhere past `app create` used to leave *no* row at all, so
    the next boot re-ran bootstrap and minted yet another orphan app; a `pending`
    row makes the next attempt resume through `_relaunch` with the same app id.
-8. `liveware tunnel bind` — a **one-shot** CLI call (CLI v0.0.11+): it
+9. `liveware tunnel bind` — a **one-shot** CLI call (CLI v0.0.11+): it
    registers the app→local-upstream mapping on the control plane, prints the
    binding table (parsed for the public URL) and exits. It does **not** stay
-   running.
-9. Start the persistent `liveware agent` data-plane daemon
-   (`start_tunnel_agent`) — the long-lived child that actually carries
-   public-URL traffic to the local upstream. Ready once it logs
-   `relay grpc control connected` (again, no crash watcher yet).
+   running. If step 6 did not confirm an existing service, start a persistent
+   `liveware agent` child and attach it to the supervisor lifecycle.
 10. `register_app(name, app_id, url)` against ClawChat, upsert the
-   `liveware_sample` row with `status="active"`, **then** attach crash
-   watchers to both child processes (server and agent), and deliver an
-   intro message to the owner's direct chat (retried — see
+   `liveware_sample` row with `status="active"`, **then** attach a crash
+   watcher to the sample server and, only for the direct-start fallback, its
+   tunnel agent. Finally deliver an intro message to the owner's direct chat
+   (retried — see
    [Owner intro delivery](#owner-intro-delivery)).
 
-Steps up to and including the agent start bail out (and kill whatever
-children are live) if the supervisor was stopped or the generation was
+Steps up to and including the conditional agent start bail out (and kill any
+owned children) if the supervisor was stopped or the generation was
 bumped mid-sequence — a stale flow never overwrites a live status with an
 outdated `"active"` write, with two deliberate exceptions. There is **no bail
-point between `app create` and the `pending` upsert** (step 6 → 7): bailing
+point between `app create` and the `pending` upsert** (step 7 → 8): bailing
 there is exactly what used to lose a freshly minted app id. And from
 `register_app` onward there is deliberately
 **no bail point until the row is upserted**: once the app card exists on the
-server, a mid-sequence child crash must not abort the flow before the row is
-persisted, or it would leave an orphaned app card with nothing for the
+server, a mid-sequence owned-child crash must not abort the flow before the row
+is persisted, or it would leave an orphaned app card with nothing for the
 relaunch path to find. Crash watchers therefore attach only *after* the
 upsert, with a synchronous `proc.returncode is not None` check at attach
 time, so a child that already exited during the earlier awaits is still
@@ -172,7 +176,7 @@ login entirely. It exists because the `liveware` CLI keeps its credentials in
 plugin's SQLite state dir) — a different volume in a containerized deployment.
 A container that persists `$HERMES_HOME` but not `$HOME` therefore comes back
 with a `liveware_sample` row (which forces this relaunch path) **and** a
-logged-out CLI, so every `tunnel bind` / `liveware agent` call failed auth,
+logged-out CLI, so `tunnel bind` and the CLI-managed agent failed auth,
 the `_START_RETRY_DELAYS_S` ladder burnt out, and the sample never returned
 for the rest of the process lifetime.
 
@@ -264,7 +268,8 @@ unchanged).
   `LivewareSampleSupervisor.adoptDeps`; hermes needs no `adopt_deps` because
   every dep is read lazily off the live adapter instance rather than captured in
   a per-call gateway closure.)
-- **Crash backoff**: each watched child (server or `liveware agent`) that exits
+- **Crash backoff**: when the watched sample server or a plugin-started
+  `liveware agent` exits
   unexpectedly triggers a relaunch after a delay of `min(5 * 2**n, 60)`
   seconds, where `n` is the number of restarts already counted in the
   current 30-minute window (5s, 10s, 20s, 40s, 60s, ...). After 5 restarts
@@ -272,8 +277,9 @@ unchanged).
   supervisor stops trying until the next process start.
 - **`disconnect()`**: `_stop_liveware_sample` cancels any in-flight
   supervisor start task and calls `LivewareSampleSupervisor.stop()`, which
-  kills the sample server and tunnel child processes and cancels its
-  internal watcher/relaunch tasks, then clears
+  kills the sample server and any plugin-started tunnel child, then cancels its
+  internal watcher/relaunch tasks. An already-running external Liveware service
+  has no process handle in the supervisor and is left untouched. It then clears
   `self._liveware_sample_supervisor` back to `None` — so the **next**
   connect after a disconnect builds a fresh supervisor and goes through
   `start()` again.

--- a/docs/skill-updates.md
+++ b/docs/skill-updates.md
@@ -87,7 +87,8 @@ is expected, not a bug: the managed tree is meant to always converge to
 whatever the official manifest says, never to preserve local edits.
 
 Publish-side constraint: the official manifest's version for a bundled skill
-(`clawchat-core`, `clawchat-liveware`, `clawchat-liveware-sample`) must never be **lower** than the version already
+(`clawchat-core`, `clawchat-liveware`, `clawchat-liveware-dev`,
+`clawchat-liveware-sample`) must never be **lower** than the version already
 shipped in the plugin's own bundled snapshot. `seed_managed_skill` reseeds the
 managed copy from the bundled snapshot whenever the managed version is older
 than the bundled one — a manifest that regresses a bundled skill's version

--- a/docs/skill-updates.md
+++ b/docs/skill-updates.md
@@ -201,7 +201,7 @@ order:
    never hot-registered (there is nothing to register).
 2. **Skills-index visibility**: `skill_update.ensure_external_skills_dir()`
    idempotently lists the managed dir (relative entry `clawchat-skills`;
-   the host resolves it against `$HERMES_HOME`) in the host config's
+   relative to the active Hermes home directory) in the host config's
    `skills.external_dirs`. Directories there are scanned into the system
    prompt's `<available_skills>` index and `skills_list`, and the host
    treats them as externally owned (read-only for its autonomous skill

--- a/skills/clawchat-liveware-dev/SKILL.md
+++ b/skills/clawchat-liveware-dev/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: clawchat-liveware-dev
+version: 1.0.0
+description: Use when building or modifying a web app intended to run behind ClawChat Liveware. Covers distinctive frontend design with native HTML, CSS, and JavaScript, a lightweight Python backend, content-hashed static assets, and correct HTTP cache headers. Use clawchat-liveware separately for app creation, binding, access policy, inspection, and removal.
+---
+
+# ClawChat Liveware Development
+
+Build a small, self-contained web service that runs in a constrained agent environment and
+is ready to expose through Liveware. Favor source code the agent can run directly over a
+toolchain it must install or compile.
+
+## Hard constraints
+
+- Build the frontend with semantic HTML, CSS, and browser-native JavaScript. For a new app,
+  create no `package.json`, `node_modules`, JSX, TSX, TypeScript compiler, bundler, or npm
+  build step. Use Web APIs and ES modules only when plain JavaScript needs modularity.
+- Prefer a Python 3 backend. Start with the standard library; add a small Python framework
+  only when the requested behavior clearly needs it and the dependency is already available
+  or can be installed without introducing a frontend toolchain.
+- Listen on `127.0.0.1`, not a public interface. Liveware owns public exposure.
+- Give every externally served JavaScript, CSS, image, font, and other static asset a
+  content hash in its filename. A query string alone is not a content fingerprint.
+- Fingerprinted assets are long-lived and immutable. HTML and API responses are always
+  revalidated or non-cacheable so clients discover new asset filenames and fresh data.
+- Keep creation and publishing separate. Finish and verify the local service here, then use
+  the `clawchat-liveware` skill for Liveware app creation, binding, permissions, and removal.
+
+## Workflow
+
+1. **Ground the brief.** Identify one concrete subject, its audience, and the page's single
+   primary job. If the user left one of these open, choose it from available context and state
+   the assumption. Inventory the required pages, API operations, persisted data, and viewer
+   identity needs. This step is complete when every screen and endpoint serves that primary
+   job.
+
+2. **Choose a visual direction before coding.** Produce a compact internal design plan:
+
+   - four to six named color tokens with exact values;
+   - deliberate display, body, and utility type roles using system fonts or bundled,
+     fingerprinted font files;
+   - a responsive layout concept, sketched as a small ASCII wireframe when layout is not
+     obvious;
+   - one memorable signature element grounded in the app's subject.
+
+   Spend visual boldness on that signature element and keep the rest disciplined. Revise any
+   choice that could be pasted unchanged into an unrelated product. Structural labels,
+   numbering, motion, and decoration must communicate something real. Write controls from the
+   user's perspective with stable, active labels: an action called “Save” produces a “Saved”
+   result. Empty and error states say what happened and what the user can do next.
+
+3. **Design the no-build file layout.** Prefer this shape unless the existing app has an
+   equally simple convention:
+
+   ```text
+   app/
+     server.py
+     tools/fingerprint_assets.py
+     web/index.template.html
+     web/assets-src/app.css
+     web/assets-src/app.js
+     web/public/index.html             # generated entry document
+     web/public/assets/                 # generated fingerprinted files
+     web/public/asset-manifest.json     # generated source-to-output mapping
+   ```
+
+   Keep authored and generated files separate. Prefer one CSS file and one JavaScript file per
+   page so hashing stays transparent. If multiple native modules are necessary, fingerprint
+   leaf modules first, rewrite their import specifiers, and then fingerprint importers.
+
+4. **Implement the Python service.** Use explicit routes for HTML, assets, health, and APIs.
+   Resolve filesystem paths against the static root and reject traversal. Set correct content
+   types, UTF-8 encode text, constrain request body sizes, validate JSON shapes, escape
+   untrusted values rendered into HTML, and return structured JSON errors. State-changing
+   operations accept only their intended HTTP methods.
+
+   For viewer-aware behavior, read `X-User-Id` or `X-Clawchat-User-Id` on the server. Treat the
+   value as identity only for traffic arriving through the Liveware tunnel; never copy it from
+   browser input or expose privileged operations on a client-asserted id.
+
+5. **Implement the native frontend.** Use DOM APIs, `fetch`, events, forms, CSS custom
+   properties, and progressive enhancement. Keep state and rendering small and explicit.
+   Handle loading, empty, success, and failure states. Use semantic controls, visible keyboard
+   focus, sufficient contrast, usable touch targets, mobile layouts, and
+   `prefers-reduced-motion`. Avoid remote CDN scripts; vendor a truly necessary dependency as
+   a fingerprinted static file and record why it is needed.
+
+6. **Fingerprint every static asset.** The Python preparation script must:
+
+   - hash the final served bytes with SHA-256 and place at least 12 hexadecimal characters in
+     the filename, for example `app.8c7f2a91d4e6.js`;
+   - preserve the extension so MIME detection remains correct;
+   - write a deterministic `asset-manifest.json` mapping logical names to hashed paths;
+   - rewrite CSS `url(...)`, HTML references, and JavaScript module imports to the hashed
+     dependency names before hashing their parent files;
+   - generate `index.html` from exact placeholders in `index.template.html`;
+   - leave an existing hashed filename immutable: the same path must always serve the same
+     bytes;
+   - run before the server accepts requests, using Python only. It is asset preparation, not a
+     frontend compilation step.
+
+   Keep the public entry URL stable. Do not hash `index.html`; it must fetch or revalidate on
+   every visit so it can point at the latest asset hashes. Retain previous hashed assets long
+   enough for in-flight or previously loaded HTML to finish using them.
+
+7. **Apply cache policy by response class.** Set headers on successes and errors, including
+   `HEAD` and `OPTIONS` responses where supported:
+
+   | Response | Required `Cache-Control` |
+   | --- | --- |
+   | Fingerprinted assets | `public, max-age=31536000, immutable` |
+   | `index.html` and other HTML entry documents | `no-cache, max-age=0, must-revalidate` |
+   | `asset-manifest.json` | `no-cache, max-age=0, must-revalidate` |
+   | Every `/api/` response | `no-store, no-cache, max-age=0, must-revalidate` |
+   | Health and dynamic status responses | `no-store` |
+
+   API responses also send `Pragma: no-cache` and `Expires: 0` for older intermediaries. A
+   framework's default behavior does not count as verification; add middleware or a shared
+   response helper so every API path, including validation and server errors, gets the policy.
+
+8. **Verify behavior and presentation.** At minimum:
+
+   - run `python3 -m compileall` and the backend's focused tests;
+   - start the service on loopback and require the health endpoint to succeed;
+   - request HTML, every referenced asset, representative API successes, and API errors;
+   - assert all served asset URLs contain the hash of their exact bytes;
+   - change one source asset, prepare again, and assert its public filename changes while the
+     generated HTML references the new name;
+   - inspect headers and require immutable caching only on fingerprinted assets and no-store
+     behavior on every API response;
+   - test narrow mobile and desktop layouts, keyboard navigation, reduced motion, and empty and
+     error states; use screenshots for visual critique when browser tooling is available;
+   - confirm the project starts with Python alone and no npm or frontend compilation command.
+
+The app is ready only when the cache-bust test, header checks, local service smoke test, and
+visual/accessibility review all pass. Report the local URL, start command, persisted-data path,
+and verification results before handing publishing to `clawchat-liveware`.
+
+## Implementation cautions
+
+- Calculate hashes from final output bytes, after dependency URLs are rewritten. Hashing source
+  bytes and then changing them produces a lying filename.
+- Avoid putting user-specific or secret data in static files: immutable public caches may retain
+  those bytes for a year.
+- Do not let an API path fall through to the static-file handler; a mistaken immutable header on
+  dynamic JSON can leak stale or user-specific data.
+- Keep generated assets deterministic. Timestamps, random ids, absolute paths, and host-specific
+  line endings create needless new hashes.
+- A service restart may regenerate identical filenames for identical bytes. That is correct and
+  preserves cache efficiency.

--- a/skills/clawchat-liveware/SKILL.md
+++ b/skills/clawchat-liveware/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clawchat-liveware
-version: 1.2.1
-description: Use when the user wants to expose this agent's local web service to the public internet via the liveware CLI and make it appear as an app in their ClawChat chat with this agent. Covers logging in to liveware with the ClawChat account, creating a liveware app, binding a tunnel to a local port, and registering the public URL to ClawChat, and restricting who may open a liveware (it is open to anyone with the link by default; viewer permissions are managed by the liveware CLI itself, not by ClawChat).
+version: 1.2.6
+description: Use when the user wants to expose this agent's local web service to the public internet via the liveware CLI and make it appear as an app in their ClawChat chat with this agent. Covers logging in to liveware with the ClawChat account, creating a liveware app, binding a tunnel to a local port, registering the public URL to ClawChat, restricting who may open each app, and fully unregistering and deleting an app.
 ---
 
 # liveware App Hosting
@@ -33,8 +33,12 @@ ClawChat so it shows as an app tile in the owner's chat with this agent.
    is then exactly `http://127.0.0.1:<port>`.
 3. **List existing apps** to avoid duplicates and to recover ids:
    `liveware app list`
-4. **Create the app** (skip if reusing an existing one):
-   `liveware app create "<app name>"`
+4. **Create the app with its access policy** (skip if reusing an existing one):
+   `liveware app create "<app name>" --policy <public|private|allowlist>`
+   - For `allowlist`, include the complete initial viewer list with repeatable
+     `--allow-user <user id>` flags or one `--allow-users <user1,user2>` flag.
+   - Access policy belongs to this exact app; it does not change any other app. If the
+     user did not choose a policy, explain that the default is `public` before creating it.
    - This prints/returns the new **app id**. Capture it.
    - If liveware reports an app-limit / quota error, relay that error to the user verbatim
      and STOP. Do not delete other apps to make room.
@@ -43,17 +47,69 @@ ClawChat so it shows as an app tile in the owner's chat with this agent.
    shell that interpolates unvalidated user input:
    `liveware tunnel bind <app id> http://127.0.0.1:<port>`
    - Capture the **public URL** liveware returns.
-6. **Register to ClawChat** so it appears in the owner's chat — call the tool, do NOT
+6. **Verify the bind and relay connection** through the public URL:
+   `curl --fail --silent --show-error '<public URL>/liveware-status'`
+   - Relay registration is asynchronous. Retry this read-only GET every 2 seconds for up
+     to 60 seconds.
+   - HTTP 200 alone is not success. Require JSON `code == 0`, `data.appId` equal to the
+     exact app id from step 4, and `data.bound`, `data.relayConnected`, and `data.live` all
+     equal to `true`.
+   - `bound` means the control plane resolves the app to a tunnel instance;
+     `relayConnected` means that instance has connected to the relay; `live` means both
+     conditions are ready.
+   - If the deadline expires, report the last response and run the read-only
+     `liveware status` and `liveware app list` commands to distinguish an incomplete bind
+     from a disconnected agent. STOP without creating another app or repeating the bind.
+     Treat an app-id mismatch as the wrong URL or app, not as a transient state.
+   - This endpoint checks control-plane and relay state, not the local web service. Also
+     confirm `http://127.0.0.1:<port>` responds successfully. An unauthenticated request to
+     the normal public application path may be rejected even when `/liveware-status` is
+     healthy.
+7. **Register to ClawChat** so it appears in the owner's chat — call the tool, do NOT
    curl the API directly:
    `clawchat_register_app(name="<app name>", appId="<app id>", url="<public URL>")`
-7. **Confirm** to the user: report the app name and public URL, and that it now appears in
-   their chat with this agent (open the「…」menu → the app tile).
+8. **Confirm** to the user: report the app name, public URL, final `bound`,
+   `relayConnected`, and `live` values, and that it now appears in their chat with this
+   agent (open the「…」menu → the app tile).
 
-## Managing apps
+## Managing and fully removing apps
 
 - To see what is registered to ClawChat: `clawchat_list_apps()`.
-- To remove one: `clawchat_unregister_app(appId="<app id>")` (this only removes it from
-  ClawChat; tear down the liveware tunnel/app with liveware's own commands separately).
+- Removing only the ClawChat registration leaves the Liveware URL accessible. Treat app
+  removal as complete only after both the ClawChat registration and the Liveware app are
+  gone.
+
+For a full removal:
+
+1. Treat the user's initial removal request only as permission to inspect. Run
+   `clawchat_list_apps()` and `liveware app list`, resolve one exact app id, then run
+   `liveware app inspect <exact app id>`. Perform no mutation in this step.
+2. Show the user the exact app id, app name, current access policy, and that confirmation
+   will remove both its ClawChat tile and Liveware public route. Keep the public URL from
+   the inspection for later verification, but omit it from the confirmation prompt. Ask
+   for an explicit second confirmation after showing the other details. The initial
+   removal request is not this confirmation; end the turn without unregistering or
+   deleting anything.
+3. After the user confirms, re-run `clawchat_list_apps()`, `liveware app list`, and
+   `liveware app inspect <exact app id>`. Continue only if the id, name, URL, and access
+   policy still match the inspected snapshot, and the displayed fields match what the
+   user confirmed. If any field changed or the target is ambiguous, show the updated id,
+   name, and access policy and request confirmation again without displaying the URL.
+4. Remove the tile from ClawChat:
+   `clawchat_unregister_app(appId="<exact app id>")`
+   Stop if this fails; do not delete the Liveware app while its ClawChat registration is
+   unresolved.
+5. Remove the public route, tunnel binding, and access policy:
+   `liveware app delete <exact app id>`
+   `app delete` performs the Liveware-side unbind, so a separate `tunnel unbind` is not
+   required.
+6. Verify the exact app id is absent from both `clawchat_list_apps()` and
+   `liveware app list`. Poll the former public URL's `/liveware-status` for up to 60
+   seconds; completion requires it to stop reporting that app as `live: true` (a not-found
+   response or `bound: false`, `relayConnected: false`, and `live: false` is expected).
+7. Report full removal only when both inventories and the public status check pass. If the
+   Liveware deletion fails after ClawChat unregisters, report a partial removal and the
+   still-accessible app id; do not hide the failure or retry with a different command.
 
 ## Identifying the viewing user (server-side)
 
@@ -76,54 +132,38 @@ Caveats:
 
 ## Viewer permissions (who may open this liveware)
 
-**A liveware is open to everyone by default.** Once it is tunnelled, anyone who has the
-URL can open it — the platform's only gate is a ClawChat login wall, which does not care
-*which* user is behind it. So "let this person see it" normally needs no action at all,
-and forwarding the link to someone IS effectively granting them access. What actually
-needs the CLI is the opposite: **narrowing** who may open it.
+Access is configured independently for each exact app id through the liveware CLI:
 
-Who may open a liveware is controlled by the **liveware CLI itself**, not by ClawChat.
-ClawChat's own record of the app (`clawchat_register_app` / `clawchat_list_apps`) only
-decides whether a tile shows up in the owner's chat — that record carries no per-viewer
-visibility field. So changing another ClawChat user's access is always a liveware-CLI
-operation, and there is no ClawChat API that does it.
+- `public`: anyone who passes the platform's entry authentication can open the app.
+- `private`: only the app owner can open it.
+- `allowlist`: the owner plus the listed ClawChat user ids can open it.
 
-**Discover the command before running it — never guess it.** This skill deliberately does
-NOT hard-code the permission subcommand names, because they differ between liveware
-versions. Find them at run time:
+ClawChat app registration only controls whether the tile appears in chat; it does not
+store or change viewer permissions.
 
-1. `liveware --help`
-2. `liveware app --help`, then the `--help` of whichever permission-related subcommand it
-   lists (e.g. `liveware app <that subcommand> --help`).
+To change one app:
 
-Use only subcommands and flags that actually appear in that help output. If the installed
-liveware lists nothing permission-related, it does not support viewer permissions — say so
-plainly and STOP. Do NOT work around it by editing liveware config files, by calling the
-ClawChat API, or by inventing a command line.
+1. Run `liveware app inspect <exact app id>` and confirm its name, owner, and current
+   access policy match the user's intended target.
+2. Confirm the complete desired policy with the owner. Widening access can disclose the
+   app; narrowing access can remove existing viewers.
+3. Run exactly one of:
+   - `liveware app access <exact app id> --policy public`
+   - `liveware app access <exact app id> --policy private`
+   - `liveware app access <exact app id> --policy allowlist --allow-user <user id>`
+   - `liveware app access <exact app id> --policy allowlist --allow-users <user1,user2>`
+4. For `allowlist`, provide every non-owner user who should retain access. The command
+   replaces that app's complete allowlist; it is not an incremental add. The owner remains
+   allowed automatically.
+5. Re-run `liveware app inspect <exact app id>` and require the reported policy and full
+   allowlist to match the requested state. Then probe `<public URL>/liveware-status` and
+   require the same healthy result defined in procedure step 6. Report both access and
+   tunnel state.
 
-**Tell the owner the default, and confirm before every change.** A liveware has no
-per-user access control *inside* the page: anyone who can open it sees exactly the same
-features and data the owner sees, and can forward the URL on. Two consequences:
-
-- **When the owner publishes a liveware, say plainly that it is open to anyone with the
-  link.** Do not let them assume it is private because it only shows as a tile in their
-  own chat — that tile is not a boundary.
-- **Restricting is the useful operation, and it may break other viewers.** Confirm with
-  the owner, in their own words, **which app** and **who should keep access** before you
-  narrow it; report exactly what you changed.
-- A widening change (opening something the owner had narrowed) is an irreversible
-  disclosure — confirm it the same way, never on a third party's request, and never
-  proactively "to be helpful".
-- Pass user ids exactly as the owner supplies them, or as observed server-side from the
-  `X-User-Id` / `X-Clawchat-User-Id` header (see "Identifying the viewing user"). Never
-  guess an id, and never paste unvalidated text into a shell command.
-- Never read, print, or pass the ClawChat access token in any of these commands — the
-  plugin holds it (see "Prerequisites").
-
-**Verify and report.** After a change, re-run the CLI's own list/show command for that app
-and report the resulting access state back to the owner — including whether it is still
-open to everyone. If the CLI errors (unknown user, quota, not the app owner), relay the
-error verbatim rather than retrying with a different command shape.
+Pass user ids exactly as the owner supplies them or as observed server-side from
+`X-User-Id` / `X-Clawchat-User-Id`. Never guess an id or apply one app's permission request
+to another app. If the CLI rejects the change, relay the error and stop; do not edit
+liveware config files or call ClawChat APIs as a workaround.
 
 ## Notes
 

--- a/skills/clawchat-liveware/SKILL.md
+++ b/skills/clawchat-liveware/SKILL.md
@@ -28,8 +28,8 @@ ClawChat so it shows as an app tile in the owner's chat with this agent.
    activated, or login failed), relay that error to the user and STOP.
 2. **Decide the app name and local port.** Ask the user for the local web service port if
    not already known (the port the agent's own web server listens on). Accept ONLY a plain
-   integer in the range 1–65535. Reject anything that is not purely numeric (e.g.
-   `3000; rm -rf /`) — never paste user-supplied text into a shell command. The bind target
+   integer in the range 1–65535. Reject nonnumeric input (such as `3000abc`), including
+   shell operators and additional commands — never paste user-supplied text into a shell command. The bind target
    is then exactly `http://127.0.0.1:<port>`.
 3. **List existing apps** to avoid duplicates and to recover ids:
    `liveware app list`

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -9,10 +9,16 @@
         "bytes": 9278
       },
       "clawchat-liveware": {
-        "version": "1.2.1",
+        "version": "1.2.6",
         "path": "shared/clawchat-liveware/SKILL.md",
-        "sha256": "a548b10fb68a1dddea93fadb5d162449c6745f9c2b8eb8ae76b110e28b6bf658",
-        "bytes": 8167
+        "sha256": "a5ff6e9891a2fb7df3906a8f756f0dc8c9786dcb3173ce44d009e5d5d67a86fd",
+        "bytes": 10668
+      },
+      "clawchat-liveware-dev": {
+        "version": "1.0.0",
+        "path": "shared/clawchat-liveware-dev/SKILL.md",
+        "sha256": "5dcf3fc1507f381eb6167c37204570324274fb9c068c25897311cf3ba11dd8b0",
+        "bytes": 8892
       },
       "clawchat-set-greeting": {
         "version": "1.0.0",
@@ -35,10 +41,16 @@
         "bytes": 17557
       },
       "clawchat-liveware": {
-        "version": "1.2.1",
+        "version": "1.2.6",
         "path": "shared/clawchat-liveware/SKILL.md",
-        "sha256": "a548b10fb68a1dddea93fadb5d162449c6745f9c2b8eb8ae76b110e28b6bf658",
-        "bytes": 8167
+        "sha256": "a5ff6e9891a2fb7df3906a8f756f0dc8c9786dcb3173ce44d009e5d5d67a86fd",
+        "bytes": 10668
+      },
+      "clawchat-liveware-dev": {
+        "version": "1.0.0",
+        "path": "shared/clawchat-liveware-dev/SKILL.md",
+        "sha256": "5dcf3fc1507f381eb6167c37204570324274fb9c068c25897311cf3ba11dd8b0",
+        "bytes": 8892
       },
       "clawchat-set-greeting": {
         "version": "1.0.0",

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -43,8 +43,8 @@
       "clawchat-liveware": {
         "version": "1.2.6",
         "path": "shared/clawchat-liveware/SKILL.md",
-        "sha256": "a5ff6e9891a2fb7df3906a8f756f0dc8c9786dcb3173ce44d009e5d5d67a86fd",
-        "bytes": 10668
+        "sha256": "a9f3bb9fc0a34123fb2264d26e21ec2fd239fb48b9ea1a0c7fe9a70ac2f9b0b7",
+        "bytes": 10696
       },
       "clawchat-liveware-dev": {
         "version": "1.0.0",


### PR DESCRIPTION
## Summary

- probe `liveware status` after login and reuse an already-running agent service instead of spawning and watching a duplicate process
- expand `clawchat-liveware` with bind health verification, per-app access policies, complete removal, and read-only plus explicit second-confirmation safeguards
- add `clawchat-liveware-dev` for distinctive native HTML/CSS/JavaScript apps with Python backends, content-hashed static assets, and strict cache policies
- update bundled skill manifest and packaging documentation

## Verification

- `python3 -m compileall -q clawchat_gateway`
- exercised running, stopped, and nonzero-exit `liveware status` paths
- parsed all updated Skill frontmatter and `skills/manifest.json`
- `git diff --check`
- deployed to test instance `cas-ab498cca46951f9aa42dcdb9e2aefefc`; managed Skill registration verified, `hermes-agent` restarted successfully, Pod Ready with zero container restarts
- test release gate passed