### PR TITLE
fix(liveware): calibrate the status probe against real CLI output

### DIFF
--- a/clawchat_gateway/liveware_sample.py
+++ b/clawchat_gateway/liveware_sample.py
@@ -254,16 +254,23 @@ _LONE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{5,}$")
 # ("active"/"running", which _LONE_ID_RE alone happily accepts) can never be
 # mistaken for an app id in `app list`'s text table. See _is_app_id_token.
 _ID_CHAR_RE = re.compile(r"[0-9_-]")
-# `liveware status`'s running marker. Deliberately anchored to a whole line:
-# this is the ONE parser in this module with no captured-output fixture behind
-# it (the CLI was not available when it was written), so it is written to fail
-# closed. A substring match would let an unrelated line - an error message
-# quoting a status, another app's row - read as "running", and a false positive
-# here means no data plane is ever started behind a live app card. A false
-# negative only costs one extra `liveware agent` process. Tighten-only:
-# do not loosen this without a fixture.
+# `liveware status`'s running marker, calibrated against liveware v0.0.33
+# (commit e431646). The command prints ONE sentence and exits 0 whatever the
+# state - the exit code carries no signal at all:
+#     Liveware agent service status: not_installed.
+#     Liveware agent service status: running.
+# from the format string `Liveware agent service status: %s.`, whose values are
+# not_installed / running / stopped / starting / installed / unknown / failed.
+#
+# Anchored to that whole sentence on purpose. A substring match on
+# `status: running` - which is what this first shipped as - also matches an
+# error line quoting a status, or `... status: running-degraded`, and a false
+# positive here means no data plane is ever started behind a live app card.
+# A false negative only costs one extra `liveware agent` process, so ambiguity
+# must resolve to no-match. Re-check against captured output before touching.
 _AGENT_STATUS_RUNNING_RE = re.compile(
-    r"^[ \t]*status[ \t]*:[ \t]*running[ \t]*\r?$", re.IGNORECASE | re.MULTILINE
+    r"^[ \t]*Liveware agent service status:[ \t]*running[ \t]*\.?[ \t]*\r?$",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 SpawnFn = Callable[..., "Awaitable"]
@@ -275,11 +282,12 @@ _CLI_TIMEOUT = 30.0
 
 
 def parse_agent_status_running(output: str) -> bool:
-    """True only when `liveware status` stdout carries a whole `status: running` line.
+    """True only for `liveware status`'s own "running" sentence on stdout.
 
-    Pure so it is testable without the CLI. Anything else - an older CLI that
-    has no `status` subcommand, help text, a status word merely mentioned inside
-    a sentence - is False by design; see _AGENT_STATUS_RUNNING_RE.
+    Pure so it is testable without the CLI; the fixtures live in
+    tests/test_liveware_agent_status.py. Anything else - an older CLI with no
+    `status` subcommand, help text, a status word quoted inside some other
+    sentence - is False by design; see _AGENT_STATUS_RUNNING_RE.
     """
     return _AGENT_STATUS_RUNNING_RE.search(output) is not None
 
@@ -629,9 +637,13 @@ async def liveware_agent_is_running(
     """`liveware status` -> True only if it positively confirms a running agent.
 
     Best-effort by contract and deliberately biased to False: an exec failure, a
-    non-zero exit (what an older CLI without `status` gives), or output this
+    non-zero exit (an older CLI with no `status` subcommand), or output this
     parser does not positively recognise all resolve to False with a debug log,
     so the caller keeps its direct `liveware agent` fallback. Never raises.
+
+    On v0.0.33 the exit code carries NO signal - `status` exits 0 for every
+    state including not_installed - so the parsed sentence is the only evidence
+    there is. The returncode check below is purely a guard for other builds.
 
     The asymmetry is the whole point. A wrong False costs one redundant agent
     process; a wrong True means the tunnel is never started while the app card

--- a/docs/liveware-sample.md
+++ b/docs/liveware-sample.md
@@ -117,12 +117,24 @@ own. Only a genuine **opt-out** returns without scheduling anything:
    `start_tunnel_agent`, ready once it logs `relay grpc control connected`
    (again, no crash watcher yet).
 
-   The probe fails closed. It reads stdout only, requires a whole
-   `status: running` line, and treats an exec failure, a non-zero exit (what an
-   older CLI without `status` returns) or any unrecognised output as "not
-   running" — a redundant agent process is a far cheaper mistake than a live
-   app card with no data plane behind it. **This is the one CLI parser in the
-   module with no captured-output fixture; do not loosen it without one.**
+   The probe fails closed. It reads stdout only and requires `liveware status`'s
+   own whole sentence, calibrated against **liveware v0.0.33** (commit
+   `e431646`):
+
+   ```
+   Liveware agent service status: not_installed.
+   Liveware agent service status: running.
+   ```
+
+   from that build's `Liveware agent service status: %s.` format string, over
+   the values `not_installed` / `running` / `stopped` / `starting` /
+   `installed` / `unknown` / `failed`. **`status` exits 0 for every one of
+   them**, so the exit code carries no signal and the sentence is the only
+   evidence; the non-zero-exit branch is a guard for other builds only. An exec
+   failure or any unrecognised output means "not running" — a redundant agent
+   process is a far cheaper mistake than a live app card with no data plane
+   behind it. Fixtures in `tests/test_liveware_agent_status.py`; re-check them
+   against captured output before touching the regex.
 
    Adoption is allowed only where a running agent must belong to a *previous*
    plugin process: `_bootstrap` and the process-start call of `_relaunch`

--- a/docs/token-refresh.md
+++ b/docs/token-refresh.md
@@ -239,7 +239,9 @@ backpressure, handshake-timeout) — backoff-reconnect with the same token + dev
 those closes carry timing the client must honour: **`4001`** (takeover) → raise the reconnect
 floor to ≥ 5 s (msghub §3.6); **`4002`** (`duplicate_session_throttled`, opt-in) → wait the JSON
 close reason's `retry_after_ms` (60 s, doubling to 300 s) — longer than openclaw's `maxDelay`
-of 15 s. Neither client reads the close code today.
+of 15 s. Both clients read the close code today: openclaw in `ws-client.ts`'s
+`handleClose`, hermes in its supervisor loop in `connection.py`; each keeps its own
+takeover streak and applies these floors.
 
 ---
 


### PR DESCRIPTION
Follow-up to [#10](https://github.com/clawling/clawchat-plugin-hermes-agent/pull/10). **The probe it shipped never matched anything.**

## What was wrong

#10 required a line *starting* with `status:`. The CLI actually prints one sentence:

```
$ liveware status
Liveware agent service status: not_installed.
$ echo $?
0
```

`^status:\s*running$` cannot match that, so the probe always returned `False`. The fail-closed bias meant the bug was **invisible** — we just always spawned our own agent, which is the safe outcome — but #9's entire goal, adopting an agent left behind by a previous plugin process, was dead code.

## Calibration

Against **liveware v0.0.33** (commit `e431646`, built 2026-08-21 — the build currently served from the plugin's own unversioned download URL). Its format string is `Liveware agent service status: %s.` over `not_installed` / `running` / `stopped` / `starting` / `installed` / `unknown` / `failed`, and **`status` exits 0 for every one of them** — the exit code carries no signal, so the sentence is the only evidence. The returncode branch stays as a guard for other builds.

The new pattern keeps the fail-closed bias. Against real output:

| input | #9 | #10 | this PR |
|---|---|---|---|
| `Liveware agent service status: running.` | true | **false** ❌ | **true** ✅ |
| `Liveware agent service status: not_installed.` | false | false | false |
| `error: cannot determine status: running or stopped` | **true** ❌ | false | false |
| `Liveware agent service status: running-degraded.` | **true** ❌ | false | false |

#9 matched the happy path but false-positived; #10 killed the false positives and the happy path with them. This one gets all four right.

## Closes most of #10's "unverified CLI surface" caveat

Checked against `v0.0.33 --help`. All of these exist with **exactly** the syntax `clawchat-liveware` uses:

```
liveware app create <name> [--agent-type openclaw|hermes] [--policy public|private|allowlist] [--allow-user <userId>] [--allow-users <user1,user2>]
liveware app inspect <appId>
liveware app access <appId> --policy public|private|allowlist [--allow-user <userId>] [--allow-users <user1,user2>]
liveware app delete <appId>
```

Still unverified: `<public URL>/liveware-status`, which is served by the relay rather than the CLI. Its skill-side fallback stays in place.

## Verification

- `compileall` clean
- `pytest`: **82 passed**; the probe suite is now 23 cases carrying the captured `not_installed` output as a real fixture (`tests/` is gitignored, so it lives locally)

## Worth a separate look

The CLI download is **unversioned and never upgraded**: `liveware_cli.py` fetches `https://media.clawling.chat/liveware/liveware-<os>-<arch>` (no version in the path) and `ensure_liveware_cli()` returns early if the file already exists. An agent that downloaded months ago keeps that binary forever, and nothing ever calls `liveware --version`. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)