### PR TITLE
feat(liveware): 根据用户语言生成安装提醒

### DIFF
--- a/clawchat_gateway/adapter.py
+++ b/clawchat_gateway/adapter.py
@@ -2023,12 +2023,6 @@ class ClawChatAdapter(BasePlatformAdapter):
                 lambda client: client.register_app(name=name, app_id=app_id, url=url)
             )
 
-        async def _notify_owner(text: str) -> bool:
-            chat_id = self._owner_direct_chat_id()
-            if not chat_id:
-                return False
-            return await self._send_owner_text(chat_id, text)
-
         def _resolve_token() -> str:
             try:
                 token = load_profile_config().token
@@ -2048,7 +2042,7 @@ class ClawChatAdapter(BasePlatformAdapter):
             wait_cli_ready=wait_liveware_cli_ready,
             list_apps=_list_apps,
             register_app=_register_app,
-            notify_owner=_notify_owner,
+            notify_owner=self._dispatch_liveware_intro,
             log=logger,
         )
         self._liveware_sample_supervisor = LivewareSampleSupervisor(deps)
@@ -2084,6 +2078,49 @@ class ClawChatAdapter(BasePlatformAdapter):
         if self._liveware_sample_supervisor is not None:
             await self._liveware_sample_supervisor.stop()
             self._liveware_sample_supervisor = None
+
+    async def _dispatch_liveware_intro(self, prompt: str) -> bool:
+        """Generate the installed-app notice in the owner's existing LLM session."""
+        await self._await_owner_metadata_refreshed()
+        chat_id = self._owner_direct_chat_id()
+        owner_id = self._owner_user_id()
+        if not chat_id or not owner_id:
+            return False
+        return bool(await self._handle_inbound(InboundMessage(
+            chat_id=chat_id,
+            chat_type="direct",
+            sender_id=owner_id,
+            sender_name="",
+            text=prompt,
+            raw_message={"synthetic": True, "liveware_intro": True},
+        )))
+
+    async def _handle_liveware_intro_event(self, event: MessageEvent) -> bool:
+        """Wait for this generated turn, not merely its background dispatch.
+
+        Hermes owns session serialization. Never queue this retryable notice
+        behind a busy turn: a queued event has no task/delivery receipt yet.
+        The session task is captured immediately after dispatch, before any
+        later user turn can replace it. No host tasks are created here.
+        """
+        session_key_fn = getattr(self, "_event_session_key", None)
+        if not callable(session_key_fn):
+            logger.debug("clawchat liveware intro: host lacks session task tracking")
+            return False
+        session_key = session_key_fn(event)
+        if session_key in getattr(self, "_active_sessions", {}):
+            return False
+        chat_id = event.source.chat_id
+        before = self._visible_send_count(chat_id)
+        try:
+            await self.handle_message(event)
+            task = getattr(self, "_session_tasks", {}).get(session_key)
+            if task is not None:
+                await task
+        except Exception:
+            logger.warning("clawchat liveware intro turn failed chat_id=%s", chat_id,
+                           exc_info=True)
+        return self._visible_send_count(chat_id) > before
 
     async def _dispatch_activation_bootstrap(self) -> None:
         if self._store is None:
@@ -2549,7 +2586,7 @@ class ClawChatAdapter(BasePlatformAdapter):
             lines.append(text)
         return "\n".join(lines)
 
-    async def _handle_inbound(self, inbound: InboundMessage) -> None:
+    async def _handle_inbound(self, inbound: InboundMessage) -> bool | None:
         # Pending skill-update consent gate: an owner's direct affirm/deny reply
         # is consumed here (applies/cancels the update) and never reaches the LLM.
         # Ambiguous replies fall through to normal handling, keeping pending.
@@ -2668,6 +2705,8 @@ class ClawChatAdapter(BasePlatformAdapter):
             len(media_urls),
             reply_to_message_id,
         )
+        if inbound.raw_message.get("liveware_intro") is True:
+            return await self._handle_liveware_intro_event(event)
         await self.handle_message(event)
         logger.info(
             "clawchat dispatch accepted by hermes chat_id=%s user_id=%s",

--- a/clawchat_gateway/liveware_sample.py
+++ b/clawchat_gateway/liveware_sample.py
@@ -745,11 +745,21 @@ async def liveware_app_create(*, liveware_path, name: str, exec: ExecFn | None =
 # Port of openclaw's liveware-sample supervisor loop.
 # ---------------------------------------------------------------------------
 
-LIVEWARE_SAMPLE_INTRO_TEXT = (
-    "我给你安装了一个 liveware 演示应用「Liveware Sample」。"
-    "入口：在我们的对话页面，点右上角的「应用」按钮（✦），在打开的面板里选名为「Liveware Sample」的应用。"
-    "页面上有完整的使用引导，试试对我说：把标题改成 Hello Liveware。"
-    "你在页面上点的按钮、提交的留言我也能看到，随时问我。"
+LIVEWARE_SAMPLE_INTRO_PROMPT = (
+    "ClawChat installation notification (internal event, not a message from the user).\n"
+    "The plugin has successfully installed and registered the demo app Liveware Sample. "
+    "Reply with one brief, friendly notification in this direct conversation.\n"
+    "Use the user's explicitly preferred language; otherwise use the language of their "
+    "recent messages. If there are no such messages, use agent_owner_locale from the "
+    "owner metadata in your context; if unavailable, use English. The language of this "
+    "internal instruction is not evidence of the user's language.\n"
+    "Explain that Liveware Sample is ready. To open it, use the Apps button (✦) in "
+    "the top-right of this conversation and select Liveware Sample. Keep the app name "
+    "unchanged, but describe the navigation in the user's language. Mention that the "
+    "page includes a guide, and they can ask you to change its title to Hello Liveware "
+    "or discuss its button clicks and submitted notes.\n"
+    "Send a normal chat reply, not these instructions. Installation is already complete: "
+    "do not run tools, modify files, reinstall anything, or ask which language to use."
 )
 
 _DEFAULT_SAMPLE_PORT = 43110
@@ -1307,7 +1317,7 @@ class LivewareSampleSupervisor:
         d = self._d
         delivered = False
         try:
-            delivered = await d.notify_owner(LIVEWARE_SAMPLE_INTRO_TEXT)
+            delivered = await d.notify_owner(LIVEWARE_SAMPLE_INTRO_PROMPT)
         except Exception as exc:  # noqa: BLE001
             self._log.debug("liveware-sample intro send error: %s", exc)
         if delivered:

--- a/docs/liveware-sample.md
+++ b/docs/liveware-sample.md
@@ -314,11 +314,28 @@ unchanged).
 
 ### Owner intro delivery
 
-After a successful bootstrap, the supervisor tries to notify the owner in
-their direct chat. `notify_owner` returns `False` when the owner's direct
-chat id isn't resolvable yet (activation still in flight) — the supervisor
-retries every 30s, up to 20 tries (~10 minutes), until it succeeds or gives
-up silently.
+After a successful bootstrap, the supervisor requests an LLM-generated notice
+in the owner's existing direct-chat session, rather than sending fixed Chinese
+text. The internal installation event includes the app name, Apps-button entry
+point and suggested first interaction; it asks for a brief normal reply without
+tools or installation work. Language priority is the user's explicit preference,
+then recent user messages, then `agent_owner_locale` from refreshed owner
+metadata, with English only as the no-context fallback. Language selection and
+wording are performed by the configured Hermes model, not a translation table.
+
+The adapter waits for the host's background session task and checks visible
+delivery before reporting success. A busy session is not queued: it is retried
+later so retries cannot enqueue multiple notices behind an active conversation.
+Missing owner identity/chat, unavailable host session tracking, or a turn with
+no visible output also returns `False`. The supervisor retains its 30s retry
+interval and 20-attempt limit (~10 minutes plus turn durations). Errors after
+visible delivery do not trigger a duplicate notice. Existing `intro_sent` rows
+are unchanged; this does not resend introductions to previously notified users.
+
+Local regression coverage (requires a Hermes checkout on `PYTHONPATH`):
+`python3 -m unittest discover -s tests -p test_liveware_localized_intro.py -v`.
+It checks the real adapter dispatch and supervisor seams with model execution
+stubbed; it does not assert the language quality of a live model response.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- 将 Liveware Sample 固定中文安装通知改为 Hermes 原私聊中的 LLM 生成提醒，保留应用入口及使用建议。
- 提醒前等待 owner metadata 刷新，语言优先级为明确偏好、近期用户消息、agent_owner_locale、英文兜底。
- 会话忙时不排入重复通知，等待后台 session task，并观察实际发送后才标记 intro_sent；保留原有重试和历史已发送状态。
- 基于 main 的 8651f70，新分支不携带旧 PR #9 的历史实现。

## Verification

- 10 个本地回归测试通过：私聊身份和路由、metadata 刷新、忙时延后、等待后台发送、未发送重试、发送后异常、取消传播、supervisor 持久化。
- python3 -m compileall -q clawchat_gateway 通过。
- git diff --check 通过。
- 测试使用独立 Hermes checkout，模型执行为 stub，未验证真实模型的多语言质量，也未部署。
- 按仓库既有规则，tests/ 被 gitignore 排除；test_liveware_localized_intro.py 仅保留在本地，不包含在此 PR。文档中记录了运行命令。

## Compatibility notes

- 使用 Hermes 的 _event_session_key、_active_sessions 和 _session_tasks 来区分异步提交与完成；缺少 session tracking 的 host 不直接发送固定文案，而是走原有有限重试。
- 不重置已有 intro_sent，不向已收到通知的用户重新发送。